### PR TITLE
Add CAS indexer for worker re-indexing

### DIFF
--- a/src/main/java/build/buildfarm/common/ShardBackplane.java
+++ b/src/main/java/build/buildfarm/common/ShardBackplane.java
@@ -292,4 +292,13 @@ public interface ShardBackplane {
 
   @ThreadSafe
   OperationsStatus operationsStatus() throws IOException;
+
+  @ThreadSafe
+  boolean takeIndexerLock() throws IOException;
+
+  @ThreadSafe
+  void releaseIndexerLock() throws IOException;
+
+  @ThreadSafe
+  void runIndexer() throws IOException;
 }

--- a/src/main/java/build/buildfarm/instance/shard/CasIndexer.java
+++ b/src/main/java/build/buildfarm/instance/shard/CasIndexer.java
@@ -103,6 +103,10 @@ public class CasIndexer {
 
       // update workers on scanned keys
       ScanResult scanResult = cluster.scan(nextCursor, params);
+      if (scanResult == null) {
+        // no CAS keys available to reindex
+        return;
+      }
       List<String> keys = scanResult.getResult();
       deleteWorkersThroughIntersection(cluster, keys);
 

--- a/src/main/java/build/buildfarm/instance/shard/CasIndexer.java
+++ b/src/main/java/build/buildfarm/instance/shard/CasIndexer.java
@@ -1,0 +1,162 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.instance.shard;
+
+import static redis.clients.jedis.JedisCluster.HASHSLOTS;
+
+import build.buildfarm.common.redis.RedisSlotToHash;
+import java.util.List;
+import java.util.Set;
+import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.ScanParams;
+import redis.clients.jedis.ScanResult;
+import redis.clients.jedis.util.JedisClusterCRC16;
+
+///
+/// @class   CasIndexer
+/// @brief   Reindex CAS data in order to remove references on absent
+///          workers.
+/// @details Redis CAS entries contain reference information to the workers
+///          who have access to the underlying addressable content. However
+///          workers can disappear leaving some of these references stale. The
+///          indexer is designed to compare existing workers with all CAS
+///          entries and remove references to no longer accessible workers.
+///
+public class CasIndexer {
+
+  ///
+  /// @field   CAS_WILDCARD
+  /// @brief   The prefix for finding CAS keys.
+  /// @details Can be used in scan operations on CAS.
+  ///
+  private static final String CAS_WILDCARD = "ContentAddressableStorage:*";
+
+  ///
+  /// @field   DEFAULT_SCAN_COUNT
+  /// @brief   A default scan count.
+  /// @details Can be used in scan operations on CAS.
+  ///
+  private static final int DEFAULT_SCAN_COUNT = 10000;
+
+  ///
+  /// @field   WORKERS_KEY_NAME
+  /// @brief   The worker key name in redis.
+  /// @details Used to get all worker key names.
+  ///
+  private static final String WORKERS_KEY_NAME = "Workers";
+
+  ///
+  /// @field   TEMP_WORKER_SET
+  /// @brief   The key name for a worker set.
+  /// @details This set is temporary for performing same slot intersections.
+  ///
+  private static final String TEMP_WORKER_SET = "intersecting-workers";
+
+  ///
+  /// @field   CURSOR_SENTINAL
+  /// @brief   Cursor sentimental used by jedis.
+  /// @details Used to begin and end scan paging.
+  ///
+  private static final String CURSOR_SENTINAL = "0";
+
+  ///
+  /// @brief   Re-index the workers associated with CAS data.
+  /// @details Removes references to worker nodes that are no longer running.
+  /// @param   cluster An established jedis client to operate on a redis cluster.
+  ///
+  public static void reindexWorkers(JedisCluster cluster) {
+    // setup
+    storeActiveWorkersInAllSlots(cluster);
+
+    // worker index deletion
+    performIndexing(cluster);
+
+    // cleanup
+    deleteActiveWorkersFromAllSlots(cluster);
+  }
+  ///
+  /// @brief   Perform the indexing operation to remove workers.
+  /// @details Assumes the needed worker information is available in each slot.
+  /// @param   cluster An established jedis client to operate on a redis cluster.
+  ///
+  private static void performIndexing(JedisCluster cluster) {
+    // construct CAS query
+    ScanParams params = new ScanParams();
+    params.match(CAS_WILDCARD);
+    params.count(DEFAULT_SCAN_COUNT);
+
+    // run query and perform intersections
+    String nextCursor = CURSOR_SENTINAL;
+    do {
+
+      // update workers on scanned keys
+      ScanResult scanResult = cluster.scan(nextCursor, params);
+      List<String> keys = scanResult.getResult();
+      deleteWorkersThroughIntersection(cluster, keys);
+
+      nextCursor = scanResult.getCursor();
+    } while (!nextCursor.equals(CURSOR_SENTINAL));
+  }
+  ///
+  /// @brief   Reindex the workers through intersection.
+  /// @details Uses all the CAS keys to update their references to workers.
+  /// @param   cluster An established jedis client to operate on a redis cluster.
+  /// @param   casKeys CAS keys to reindex.
+  ///
+  private static void deleteWorkersThroughIntersection(JedisCluster cluster, List<String> casKeys) {
+    for (String casKey : casKeys) {
+      int casSlotNumber = JedisClusterCRC16.getSlot(casKey);
+      String workerKey = slotSpecificActiveWorkerSet(casSlotNumber);
+      cluster.sinterstore(casKey, workerKey, casKey);
+    }
+  }
+  ///
+  /// @brief   Store the active workers in a set designated at each slot.
+  /// @details This is done to ensure workers are available for intersection
+  ///          operations at any slot.
+  /// @param   cluster An established jedis client to operate on a redis cluster.
+  ///
+  private static void storeActiveWorkersInAllSlots(JedisCluster cluster) {
+    Set<String> workers = cluster.hkeys(WORKERS_KEY_NAME);
+    for (int i = 0; i < HASHSLOTS; ++i) {
+      String key = slotSpecificActiveWorkerSet(i);
+      cluster.del(key);
+      cluster.sadd(key, workers.stream().toArray(String[]::new));
+    }
+  }
+  ///
+  /// @brief   Delete the active workers set from each slot.
+  /// @details This is done assuming they are no longer needed.
+  /// @param   cluster An established jedis client to operate on a redis cluster.
+  ///
+  private static void deleteActiveWorkersFromAllSlots(JedisCluster cluster) {
+    for (int i = 0; i < HASHSLOTS; ++i) {
+      String key = slotSpecificActiveWorkerSet(i);
+      cluster.del(key);
+    }
+  }
+  ///
+  /// @brief   Get a set name specific to the slot number given.
+  /// @details We need sets to exist at specific slots in order to perform
+  ///          redis intersections (same slot operations).
+  /// @param   slotNumber The slot number to derive the key name for.
+  /// @return  The derived key with hashtag.
+  /// @note    Suggested return identifier: key.
+  ///
+  private static String slotSpecificActiveWorkerSet(long slotNumber) {
+    String hashtag = RedisSlotToHash.correlate(slotNumber);
+    return "{" + hashtag + "}:" + TEMP_WORKER_SET;
+  }
+}

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -1311,4 +1311,19 @@ public class RedisShardBackplane implements ShardBackplane {
                 .addAllActiveWorkers(workerSet)
                 .build());
   }
+
+  @Override
+  public boolean takeIndexerLock() throws IOException {
+    return client.call(jedis -> jedis.setnx("indexLock", "1")) == 1;
+  }
+
+  @Override
+  public void releaseIndexerLock() throws IOException {
+    client.call(jedis -> jedis.del("indexLock"));
+  }
+
+  @Override
+  public void runIndexer() throws IOException {
+    client.run(CasIndexer::reindexWorkers);
+  }
 }

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -235,6 +235,15 @@ message RedisShardBackplaneConfig {
   int32 max_pre_queue_depth = 17;
 }
 
+message IndexSettings {
+  
+  //whether or not an instance should re-index worker keys
+  bool run_indexer = 1;
+  
+  //the frequency at which re-indexing should be done
+  int32 frequency_m = 2;
+}
+
 message ShardInstanceConfig {
   bool run_dispatched_monitor = 1;
 
@@ -252,6 +261,8 @@ message ShardInstanceConfig {
   // a maximum threshold for an action's specified timeout,
   // beyond which an action will be rejected for execution
   google.protobuf.Duration maximum_action_timeout = 7;
+  
+  IndexSettings index_settings = 8;
 }
 
 message ShardWorkerInstanceConfig {

--- a/src/test/java/build/buildfarm/instance/shard/CasIndexerTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/CasIndexerTest.java
@@ -1,0 +1,95 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common.redis;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import build.buildfarm.instance.shard.CasIndexer;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.ScanParams;
+import redis.clients.jedis.ScanResult;
+
+@RunWith(JUnit4.class)
+public class CasIndexerTest {
+
+  @Mock private JedisCluster redis;
+  @Mock private ScanResult scanResult;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void reindexWithoutException() throws Exception {
+
+    // test that we can call reindexing with a mocked redis
+    // and not see any exceptions.
+    CasIndexer.reindexWorkers(redis);
+  }
+
+  @Test
+  public void exhaustScanResults() throws Exception {
+
+    // test that indexing terminates when all results are scanned
+    when(redis.scan(any(String.class), any(ScanParams.class))).thenReturn(scanResult);
+    when(scanResult.getCursor()).thenReturn("1").thenReturn("1").thenReturn("0");
+    CasIndexer.reindexWorkers(redis);
+  }
+
+  @Test
+  public void storeActiveWorkers() throws Exception {
+
+    Set<String> workerSet = new HashSet<>(Arrays.asList("worker1", "worker2", "worker3"));
+    when(redis.scan(any(String.class), any(ScanParams.class))).thenReturn(scanResult);
+    when(scanResult.getCursor()).thenReturn("0");
+    when(redis.hkeys("Workers")).thenReturn(workerSet);
+    CasIndexer.reindexWorkers(redis);
+
+    // ensure workers are added to an intersection set
+    verify(redis, times(1))
+        .sadd("{aSM}:intersecting-workers", workerSet.stream().toArray(String[]::new));
+    verify(redis, times(1))
+        .sadd("{aSN}:intersecting-workers", workerSet.stream().toArray(String[]::new));
+    verify(redis, times(1))
+        .sadd("{aSO}:intersecting-workers", workerSet.stream().toArray(String[]::new));
+  }
+
+  @Test
+  public void removedThroughInterStore() throws Exception {
+
+    when(redis.scan(any(String.class), any(ScanParams.class))).thenReturn(scanResult);
+    when(scanResult.getCursor()).thenReturn("0");
+    when(scanResult.getResult()).thenReturn(Arrays.asList("key_1", "key_2", "key_3"));
+    CasIndexer.reindexWorkers(redis);
+
+    // ensure intersections are made on the keys
+    verify(redis, times(1)).sinterstore("key_1", "{aSM}:intersecting-workers", "key_1");
+    verify(redis, times(1)).sinterstore("key_2", "{aSN}:intersecting-workers", "key_2");
+    verify(redis, times(1)).sinterstore("key_3", "{aSO}:intersecting-workers", "key_3");
+  }
+}

--- a/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
@@ -61,6 +61,7 @@ import build.buildfarm.common.Write.NullWrite;
 import build.buildfarm.instance.Instance;
 import build.buildfarm.v1test.CompletedOperationMetadata;
 import build.buildfarm.v1test.ExecuteEntry;
+import build.buildfarm.v1test.IndexSettings;
 import build.buildfarm.v1test.QueueEntry;
 import build.buildfarm.v1test.QueuedOperation;
 import com.google.common.cache.CacheBuilder;
@@ -133,7 +134,8 @@ public class ShardInstanceTest {
             /* maxBlobSize=*/ 0,
             /* maxActionTimeout=*/ Duration.getDefaultInstance(),
             mockOnStop,
-            CacheBuilder.newBuilder().build(mockInstanceLoader));
+            CacheBuilder.newBuilder().build(mockInstanceLoader),
+            IndexSettings.newBuilder().setRunIndexer(false).build());
     instance.start();
   }
 


### PR DESCRIPTION
### Summary:
Over time, buildfarm workers become inaccessible due to termination via scaling or unexpected errors.  The redis CAS keys need their references to these workers re-indexed in order to properly reflect the currently active pool of workers.  This is primarily an optimization, as stale references to workers can lead to performance issues.  We integrate an indexer to run periodically as part of buildfarm's normal operation.

The indexer runs on the server, and a global lock is used within redis.

### Note:
This functionality was ported from an internal python script to Java.