### PR TITLE
[bwob] storage workers are recognized in the backplane

### DIFF
--- a/src/main/java/build/buildfarm/common/redis/RedisHashMap.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisHashMap.java
@@ -1,0 +1,80 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common.redis;
+
+import java.util.Map;
+import redis.clients.jedis.JedisCluster;
+
+/**
+ * @class RedisHashMap
+ * @brief A redis hashmap.
+ * @details A redis hashmap is an implementation of a map data structure which internally uses redis
+ *     to store and distribute the data. Its important to know that the lifetime of the map persists
+ *     before and after the map data structure is created (since it exists in redis). Therefore, two
+ *     redis maps with the same name, would in fact be the same underlying redis map.
+ */
+public class RedisHashMap {
+  /**
+   * @field name
+   * @brief The unique name of the map.
+   * @details The name is used by the redis cluster client to access the map data. If two maps had
+   *     the same name, they would be instances of the same underlying redis map.
+   */
+  private final String name;
+
+  /**
+   * @brief Constructor.
+   * @details Construct a named redis map with an established redis cluster.
+   * @param name The global name of the map.
+   */
+  public RedisHashMap(String name) {
+    this.name = name;
+  }
+
+  /**
+   * @brief Set key to hold the string value. No TTL is available since implementation is redis
+   *     hset.
+   * @details If the key already exists, then the value is replaced.
+   * @param jedis Jedis cluster client.
+   * @param key The name of the key.
+   * @param value The value for the key.
+   * @return Whether a new key was inserted. If a key is overwritten with a new value, this would be
+   *     false.
+   */
+  public boolean insert(JedisCluster jedis, String key, String value) {
+    return jedis.hset(name, key, value) == 1;
+  }
+
+  /**
+   * @brief Remove a key from the map.
+   * @details Deletes the key/value pair.
+   * @param jedis Jedis cluster client.
+   * @param key The name of the key.
+   * @return Whether the key was removed.
+   */
+  public boolean remove(JedisCluster jedis, String key) {
+    return jedis.hdel(name, key) == 1;
+  }
+
+  /**
+   * @brief Convert the redis hashmap to a java map.
+   * @details This would not be efficient if the map is large.
+   * @param jedis Jedis cluster client.
+   * @return The redis hashmap represented as a java map.
+   */
+  public Map<String, String> asMap(JedisCluster jedis) {
+    return jedis.hgetAll(name);
+  }
+}

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -37,9 +37,9 @@ import build.buildfarm.common.function.InterruptingRunnable;
 import build.buildfarm.common.redis.BalancedRedisQueue;
 import build.buildfarm.common.redis.ProvisionedRedisQueue;
 import build.buildfarm.common.redis.RedisClient;
+import build.buildfarm.common.redis.RedisHashMap;
 import build.buildfarm.common.redis.RedisHashtags;
 import build.buildfarm.common.redis.RedisMap;
-import build.buildfarm.common.redis.RedisHashMap;
 import build.buildfarm.common.redis.RedisNodeHashes;
 import build.buildfarm.instance.Instance;
 import build.buildfarm.instance.Utils;
@@ -63,6 +63,7 @@ import build.buildfarm.v1test.QueuedOperationMetadata;
 import build.buildfarm.v1test.RedisShardBackplaneConfig;
 import build.buildfarm.v1test.ShardWorker;
 import build.buildfarm.v1test.WorkerChange;
+import build.buildfarm.v1test.WorkerType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
@@ -172,7 +173,12 @@ public class RedisShardBackplane implements Backplane {
   private RedisMap blockedInvocations;
   private RedisMap processingOperations;
   private RedisMap dispatchedOperations;
+
+  // registered workers organized by type
+  private RedisHashMap executeWorkers;
+  private RedisHashMap storageWorkers;
   private RedisHashMap mixedWorkers;
+
   private BalancedRedisQueue prequeue;
   private OperationQueue operationQueue;
   private CasWorkerMap casWorkerMap;
@@ -555,6 +561,8 @@ public class RedisShardBackplane implements Backplane {
     blockedInvocations = new RedisMap(config.getInvocationBlacklistPrefix());
     processingOperations = new RedisMap(config.getProcessingPrefix());
     dispatchedOperations = new RedisMap(config.getDispatchingPrefix());
+    executeWorkers = new RedisHashMap(config.getWorkersHashName() + "_execute");
+    storageWorkers = new RedisHashMap(config.getWorkersHashName() + "_storage");
     mixedWorkers = new RedisHashMap(config.getWorkersHashName());
 
     if (config.getSubscribeToBackplane()) {
@@ -713,8 +721,7 @@ public class RedisShardBackplane implements Backplane {
         jedis -> {
           // could rework with an hget to publish prior, but this seems adequate, and
           // we are the only guaranteed source
-          
-          boolean inserted = mixedWorkers.insert(jedis,shardWorker.getEndpoint(),json);
+          boolean inserted = mixedWorkers.insert(jedis, shardWorker.getEndpoint(), json);
           if (inserted) {
             jedis.publish(config.getWorkerChannel(), workerChangeJson);
           }
@@ -722,9 +729,18 @@ public class RedisShardBackplane implements Backplane {
         });
   }
 
+  private boolean addWorkerByType(JedisCluster jedis, ShardWorker shardWorker, String json) {
+    if (shardWorker.getType() == WorkerType.EXECUTE) {
+      return executeWorkers.insert(jedis, shardWorker.getEndpoint(), json);
+    } else if (shardWorker.getType() == WorkerType.STORAGE) {
+      return storageWorkers.insert(jedis, shardWorker.getEndpoint(), json);
+    }
+
+    return mixedWorkers.insert(jedis, shardWorker.getEndpoint(), json);
+  }
+
   private boolean removeWorkerAndPublish(JedisCluster jedis, String name, String changeJson) {
-    
-    boolean removed = mixedWorkers.remove(jedis,name);
+    boolean removed = mixedWorkers.remove(jedis, name);
     if (removed) {
       jedis.publish(config.getWorkerChannel(), changeJson);
     }

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -667,10 +667,23 @@ message ShardWorkerConfig {
   
 }
 
+// A 'worker type' helps distinguish a group of workers by their 'capabilities'.
+// A worker that can both execute & store CAS entries is known as a 'mixed worker'.
+enum WorkerType {
+  EXECUTE = 0;
+
+  STORAGE = 1;
+
+  MIXED = 2;
+};
+
+
 message ShardWorker {
   string endpoint = 1;
 
   int64 expire_at = 2;
+  
+  WorkerType type = 3;
 }
 
 message WorkerChange {

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -677,7 +677,6 @@ enum WorkerType {
   MIXED = 2;
 };
 
-
 message ShardWorker {
   string endpoint = 1;
 


### PR DESCRIPTION
### Summary:
Workers register themselves to the backplane so that other workers can find and communicate with them.  
Registering to the backplane has traditionally meant that a worker is a 'sharded CAS member', and is going to contribute to the overall cache.  With the introduction of 'storage workers' and the preservation of our current workers, we will likely need to distinguish between them.  We introduce the concept of 'worker types' via their capabilities, and allow the backplane to differentiate workers by type.  The reason this is done is to support behavior such as:
 1. having our existing workers backup data to storage workers.
 2. have storage workers find other storage workers to perform replication.
 
We may choose to make execution and storage always exclusive in our worker pool, but I think keeping these possibilities open and expanding the backplane to keep track of all workers (not just cas-related) may be a good idea.  Especially because the backplane is queried for reasons such as metrics. 

### Changes:
First we abstract the current worker map into a `JedisHashMap`.  This is done to continue our encapsulation effort of jedis usage into data structures for more flexibility between different storage backends.  Then we create a worker map for each worker type.  Our traditional workers are called 'mixed type' workers because their capabilities allow both execution and storage.  The public facing worker-related APIs remain the same for our current worker types.  Differently configured workers will register to one of the new containers.

### Overall Issue:
https://github.com/bazelbuild/bazel-buildfarm/issues/857