### PR TITLE
[config] add configuration for the operation queuer

### DIFF
--- a/examples/shard-server.config.example
+++ b/examples/shard-server.config.example
@@ -40,7 +40,17 @@ instances {
     # or no operation execution will take place.
     # The operation queuer is exclusive and should run on
     # multiple instances concurrently.
-    run_operation_queuer: true
+    operation_queuer: {
+        run: true
+        
+        operation_write_timeout_s: 60
+        
+        poll_frequency_s: 0
+        
+        poll_timeout_s: 0
+        
+        queue_concurrency: 0
+      }
 
     # The maximum size of a single blob accepted via a
     # ByteStream#write or ContentAddressableStorage#batchUpdateBlobs

--- a/examples/shard-server.config.example
+++ b/examples/shard-server.config.example
@@ -41,15 +41,28 @@ instances {
     # The operation queuer is exclusive and should run on
     # multiple instances concurrently.
     operation_queuer: {
+      
+        # Whether we should run the operation queuer.
+        # If true, we will run the operation queuer on a separate thread.
+        # If false, we will not run the operation queuer and none of these other settings will be relevant.
         run: true
         
+        # How long should we wait to write a QueuedOperation to the CAS?
+        # This timeout determines when we give up trying to write a particular QueuedOperation to the CAS.
+        # Failure to write operations may result in prequeue congestion.
         operation_write_timeout_s: 60
         
-        poll_frequency_s: 0
+        # The polling frequency for updating the expiration status of a an operation we are currently trying to queue.
+        # This could be half the watch expiry.
+        poll_frequency_s: 5
         
-        poll_timeout_s: 0
+        # How long to wait before giving up on polling.
+        # This duration represents a deadline from when the poller is created.
+        poll_timeout_s: 300
         
-        queue_concurrency: 0
+        # How many operations can the operation queuer work on concurrently?
+        # Keep in mind, this does not guarantee any amount of parallelism and will depend on the executor service.
+        queue_concurrency: 256
       }
 
     # The maximum size of a single blob accepted via a

--- a/src/main/java/build/buildfarm/instance/shard/OperationQueuerSettings.java
+++ b/src/main/java/build/buildfarm/instance/shard/OperationQueuerSettings.java
@@ -1,0 +1,68 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package build.buildfarm.instance.shard;
+
+import com.google.protobuf.Duration;
+
+/**
+ *  @class   OperationQueuerSettings
+ *  @brief   These settings are for determining how to transfer elements from
+ *           the prequeue to the operation queue.
+ *  @details The server is responsible for transferring prequeue elements to
+ *           the operation queue. The details of this transformation can be
+ *           configured here.
+ */
+public class OperationQueuerSettings {
+
+    /**
+     *  @field   run
+     *  @brief   Whether we should run the operation queuer.
+     *  @details If true, we will run the operation queuer on a seperate thread. If false, we will not run the operation queuer and none of these other settings will be relevant.
+     */
+    public   boolean  run = true;
+
+    /**
+     *  @field   operationWriteTimeout
+     *  @brief   How long should we wait to write a QueuedOperation to the CAS?
+     *  @details This timeout determines when we give up trying to write a particular QueuedOperation to the CAS. Failure to write operations may result in prequeue congestion.
+     */
+    public   Duration  operationWriteTimeout;
+
+    /**
+     *  @field   pollFrequency
+     *  @brief   The polling frequency for updating the expiration status of a an operation we are currently trying to queue.
+     *  @details This could be half the watch expiry.
+     */
+    public   Duration  pollFrequency;
+
+    /**
+     *  @field   pollTimeout
+     *  @brief   How long to wait before giving up on polling.
+     *  @details This duration represents a deadline from when the poller is created.
+     */
+    public   Duration  pollTimeout;
+
+    /**
+     *  @field   queueConcurrency
+     *  @brief   How many operations can the operation queuer work on concurrently?
+     *  @details Keep in mind, this does not guarantee any amount of parallelism and will depend on the executor service.
+     */
+    public   int  queueConcurrency = 0;
+
+
+
+}
+

--- a/src/main/java/build/buildfarm/instance/shard/OperationQueuerSettings.java
+++ b/src/main/java/build/buildfarm/instance/shard/OperationQueuerSettings.java
@@ -1,68 +1,65 @@
 // Copyright 2021 The Bazel Authors. All rights reserved.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //    http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package build.buildfarm.instance.shard;
 
 import com.google.protobuf.Duration;
 
 /**
- *  @class   OperationQueuerSettings
- *  @brief   These settings are for determining how to transfer elements from
- *           the prequeue to the operation queue.
- *  @details The server is responsible for transferring prequeue elements to
- *           the operation queue. The details of this transformation can be
- *           configured here.
+ * @class OperationQueuerSettings
+ * @brief These settings are for determining how to transfer elements from the prequeue to the
+ *     operation queue.
+ * @details The server is responsible for transferring prequeue elements to the operation queue. The
+ *     details of this transformation can be configured here.
  */
 public class OperationQueuerSettings {
+  /**
+   * @field run
+   * @brief Whether we should run the operation queuer.
+   * @details If true, we will run the operation queuer on a separate thread. If false, we will not
+   *     run the operation queuer and none of these other settings will be relevant.
+   */
+  public boolean run = true;
 
-    /**
-     *  @field   run
-     *  @brief   Whether we should run the operation queuer.
-     *  @details If true, we will run the operation queuer on a seperate thread. If false, we will not run the operation queuer and none of these other settings will be relevant.
-     */
-    public   boolean  run = true;
+  /**
+   * @field operationWriteTimeout
+   * @brief How long should we wait to write a QueuedOperation to the CAS?
+   * @details This timeout determines when we give up trying to write a particular QueuedOperation
+   *     to the CAS. Failure to write operations may result in prequeue congestion.
+   */
+  public Duration operationWriteTimeout;
 
-    /**
-     *  @field   operationWriteTimeout
-     *  @brief   How long should we wait to write a QueuedOperation to the CAS?
-     *  @details This timeout determines when we give up trying to write a particular QueuedOperation to the CAS. Failure to write operations may result in prequeue congestion.
-     */
-    public   Duration  operationWriteTimeout;
+  /**
+   * @field pollFrequency
+   * @brief The polling frequency for updating the expiration status of a an operation we are
+   *     currently trying to queue.
+   * @details This could be half the watch expiry.
+   */
+  public Duration pollFrequency;
 
-    /**
-     *  @field   pollFrequency
-     *  @brief   The polling frequency for updating the expiration status of a an operation we are currently trying to queue.
-     *  @details This could be half the watch expiry.
-     */
-    public   Duration  pollFrequency;
+  /**
+   * @field pollTimeout
+   * @brief How long to wait before giving up on polling.
+   * @details This duration represents a deadline from when the poller is created.
+   */
+  public Duration pollTimeout;
 
-    /**
-     *  @field   pollTimeout
-     *  @brief   How long to wait before giving up on polling.
-     *  @details This duration represents a deadline from when the poller is created.
-     */
-    public   Duration  pollTimeout;
-
-    /**
-     *  @field   queueConcurrency
-     *  @brief   How many operations can the operation queuer work on concurrently?
-     *  @details Keep in mind, this does not guarantee any amount of parallelism and will depend on the executor service.
-     */
-    public   int  queueConcurrency = 0;
-
-
-
+  /**
+   * @field queueConcurrency
+   * @brief How many operations can the operation queuer work on concurrently?
+   * @details Keep in mind, this does not guarantee any amount of parallelism and will depend on the
+   *     executor service.
+   */
+  public int queueConcurrency = 0;
 }
-

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -436,19 +436,10 @@ public class ShardInstance extends AbstractServerInstance {
       dispatchedMonitor = null;
     }
 
-    // get operation queuer settings
-    OperationQueuerSettings operationQueuerSettings = new OperationQueuerSettings();
-    operationQueuerSettings.run = operationQueuerConfig.getRun();
-    operationQueuerSettings.operationWriteTimeout =
-        Durations.fromSeconds(operationQueuerConfig.getOperationWriteTimeoutS());
-    operationQueuerSettings.pollFrequency =
-        Durations.fromSeconds(operationQueuerConfig.getPollFrequencyS());
-    operationQueuerSettings.pollTimeout =
-        Durations.fromSeconds(operationQueuerConfig.getPollTimeoutS());
-    operationQueuerSettings.queueConcurrency = operationQueuerConfig.getQueueConcurrency();
-
+    // Create and configure the operation queuer.
+    OperationQueuerSettings operationQueuerSettings =
+        createOperationQueuerSettings(operationQueuerConfig);
     this.transformTokensQueue = new LinkedBlockingQueue(operationQueuerSettings.queueConcurrency);
-
     if (operationQueuerSettings.run) {
       operationQueuer =
           new Thread(
@@ -623,6 +614,16 @@ public class ShardInstance extends AbstractServerInstance {
               }
             },
             "Prometheus Metrics Collector");
+  }
+
+  private OperationQueuerSettings createOperationQueuerSettings(OperationQueuerConfig config) {
+    OperationQueuerSettings settings = new OperationQueuerSettings();
+    settings.run = config.getRun();
+    settings.operationWriteTimeout = Durations.fromSeconds(config.getOperationWriteTimeoutS());
+    settings.pollFrequency = Durations.fromSeconds(config.getPollFrequencyS());
+    settings.pollTimeout = Durations.fromSeconds(config.getPollTimeoutS());
+    settings.queueConcurrency = config.getQueueConcurrency();
+    return settings;
   }
 
   private void updateLabelCount(List<LabeledCount> list, Gauge gauge) {

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -517,12 +517,24 @@ message RedisShardBackplaneConfig {
   int32 max_attempts = 33;
 }
 
+message OperationQueuerConfig {
+  bool run = 1;
+  
+  int32 operation_write_timeout_s = 2;
+  
+  int32 poll_frequency_s = 3;
+  
+  int32 poll_timeout_s = 4;
+  
+  int32 queue_concurrency = 5;
+}
+
 message ShardInstanceConfig {
   bool run_dispatched_monitor = 1;
 
   int32 dispatched_monitor_interval_seconds = 2;
-
-  bool run_operation_queuer = 3;
+  
+  OperationQueuerConfig operationQueuer = 11;
 
   oneof backplane {
     RedisShardBackplaneConfig redis_shard_backplane_config = 4;

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -534,7 +534,7 @@ message ShardInstanceConfig {
 
   int32 dispatched_monitor_interval_seconds = 2;
   
-  OperationQueuerConfig operationQueuer = 11;
+  OperationQueuerConfig operation_queuer = 11;
 
   oneof backplane {
     RedisShardBackplaneConfig redis_shard_backplane_config = 4;

--- a/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
@@ -67,6 +67,7 @@ import build.buildfarm.v1test.CompletedOperationMetadata;
 import build.buildfarm.v1test.ExecuteEntry;
 import build.buildfarm.v1test.QueueEntry;
 import build.buildfarm.v1test.QueuedOperation;
+import build.buildfarm.v1test.OperationQueuerConfig;
 import com.github.benmanes.caffeine.cache.AsyncCache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.cache.CacheBuilder;
@@ -135,6 +136,7 @@ public class ShardInstanceTest {
     blobDigests = Sets.newHashSet();
     ReadThroughActionCache actionCache =
         new ShardActionCache(10, mockBackplane, newDirectExecutorService());
+    
     instance =
         new ShardInstance(
             "shard",
@@ -143,7 +145,7 @@ public class ShardInstanceTest {
             actionCache,
             /* runDispatchedMonitor=*/ false,
             /* dispatchedMonitorIntervalSeconds=*/ 0,
-            /* runOperationQueuer=*/ false,
+            OperationQueuerConfig.newBuilder().setQueueConcurrency(256).build(),
             /* maxBlobSize=*/ 0,
             /* maxCpu=*/ 1,
             /* maxActionTimeout=*/ Duration.getDefaultInstance(),

--- a/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
@@ -65,9 +65,9 @@ import build.buildfarm.common.Write.NullWrite;
 import build.buildfarm.instance.Instance;
 import build.buildfarm.v1test.CompletedOperationMetadata;
 import build.buildfarm.v1test.ExecuteEntry;
+import build.buildfarm.v1test.OperationQueuerConfig;
 import build.buildfarm.v1test.QueueEntry;
 import build.buildfarm.v1test.QueuedOperation;
-import build.buildfarm.v1test.OperationQueuerConfig;
 import com.github.benmanes.caffeine.cache.AsyncCache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.cache.CacheBuilder;
@@ -136,7 +136,7 @@ public class ShardInstanceTest {
     blobDigests = Sets.newHashSet();
     ReadThroughActionCache actionCache =
         new ShardActionCache(10, mockBackplane, newDirectExecutorService());
-    
+
     instance =
         new ShardInstance(
             "shard",


### PR DESCRIPTION
### Summary:
Grpc timeouts when writing `QueuedOperations` to the CAS result in prequeue congestion which affects build performance.  To resolve this, we expose the grpc timeout, polling, and concurrency mechanisms as a single shard instance config so that they can be adjusted.  Servers will need to update their configuration to account for this.

### How to upgrade:
This is a breaking config change.
In order to upgrade, you will need to replace:
```
run_operation_queuer: true
```

with:

```
operation_queuer: {
    run: true
    operation_write_timeout_s: 60
    poll_frequency_s: 5
    poll_timeout_s: 300
    queue_concurrency: 256
}
```
see `examples/shard-server.config.example` as a valid example.
