### PR TITLE
[feature] allow workers to stop taking executions when expiring CAS

### DIFF
--- a/src/main/java/build/buildfarm/cas/ContentAddressableStorage.java
+++ b/src/main/java/build/buildfarm/cas/ContentAddressableStorage.java
@@ -107,6 +107,9 @@ public interface ContentAddressableStorage extends InputStreamFactory {
   @ThreadSafe
   void put(Blob blob) throws EntryLimitException, InterruptedException;
 
+  @ThreadSafe
+  boolean needsToExpire();
+
   /**
    * Insert a value into the CAS with expiration callback.
    *

--- a/src/main/java/build/buildfarm/cas/ContentAddressableStorages.java
+++ b/src/main/java/build/buildfarm/cas/ContentAddressableStorages.java
@@ -183,6 +183,11 @@ public final class ContentAddressableStorages {
         }
       }
 
+      @Override
+      public boolean needsToExpire() {
+        return false;
+      }
+
       private ByteString getData(Digest digest) {
         if (digest.getSizeBytes() == 0) {
           return ByteString.EMPTY;

--- a/src/main/java/build/buildfarm/cas/GrpcCAS.java
+++ b/src/main/java/build/buildfarm/cas/GrpcCAS.java
@@ -263,6 +263,11 @@ public class GrpcCAS implements ContentAddressableStorage {
   }
 
   @Override
+  public boolean needsToExpire() {
+    return false;
+  }
+
+  @Override
   public void put(Blob blob) throws InterruptedException {
     Chunker chunker = Chunker.builder().setInput(blob.getData()).build();
     try {

--- a/src/main/java/build/buildfarm/cas/MemoryCAS.java
+++ b/src/main/java/build/buildfarm/cas/MemoryCAS.java
@@ -154,6 +154,11 @@ public class MemoryCAS implements ContentAddressableStorage {
     return immediateFuture(getAll(digests));
   }
 
+  @Override
+  public boolean needsToExpire() {
+    return false;
+  }
+
   synchronized Iterable<Response> getAll(Iterable<Digest> digests) {
     return getAll(
         digests,

--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -2485,6 +2485,11 @@ public abstract class CASFileCache implements ContentAddressableStorage {
     }
   }
 
+  @Override
+  public boolean needsToExpire() {
+    return sizeInBytes > maxSizeInBytes;
+  }
+
   private boolean charge(String key, long blobSizeInBytes, AtomicBoolean requiresDischarge)
       throws IOException, InterruptedException {
     boolean interrupted = false;
@@ -2498,7 +2503,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
 
       ImmutableList.Builder<ListenableFuture<Digest>> builder = ImmutableList.builder();
       try {
-        while (!interrupted && sizeInBytes > maxSizeInBytes) {
+        while (!interrupted && needsToExpire()) {
           ListenableFuture<Entry> expiredFuture = expireEntry(blobSizeInBytes, expireService);
           interrupted = Thread.interrupted();
           if (expiredFuture != null) {

--- a/src/main/java/build/buildfarm/instance/Instance.java
+++ b/src/main/java/build/buildfarm/instance/Instance.java
@@ -151,6 +151,8 @@ public interface Instance {
 
   CasIndexResults reindexCas(String hostName);
 
+  boolean needsToExpire();
+
   void deregisterWorker(String workerName);
 
   class PutAllBlobsException extends RuntimeException {

--- a/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
+++ b/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
@@ -729,7 +729,8 @@ public class MemoryInstance extends AbstractServerInstance {
     synchronized (queue.workers) {
       while (!dispatched && !queue.workers.isEmpty()) {
         Worker worker = queue.workers.remove(0);
-        if (!DequeueMatchEvaluator.shouldKeepOperation(settings, worker.getProvisions(), command)) {
+        if (!DequeueMatchEvaluator.shouldKeepOperation(
+            settings, false, worker.getProvisions(), command)) {
           rejectedWorkers.add(worker);
         } else {
           QueueEntry queueEntry =
@@ -816,7 +817,7 @@ public class MemoryInstance extends AbstractServerInstance {
       DequeueMatchSettings settings = new DequeueMatchSettings();
       if (command == null) {
         cancelOperation(operationName);
-      } else if (DequeueMatchEvaluator.shouldKeepOperation(settings, provisions, command)) {
+      } else if (DequeueMatchEvaluator.shouldKeepOperation(settings, false, provisions, command)) {
         QueuedOperation queuedOperation =
             QueuedOperation.newBuilder()
                 .setAction(action)
@@ -948,6 +949,11 @@ public class MemoryInstance extends AbstractServerInstance {
   @Override
   protected int getTreeMaxPageSize() {
     return config.getTreeMaxPageSize();
+  }
+
+  @Override
+  public boolean needsToExpire() {
+    return false;
   }
 
   @Override

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -2420,6 +2420,11 @@ public class ShardInstance extends AbstractServerInstance {
   }
 
   @Override
+  public boolean needsToExpire() {
+    return false;
+  }
+
+  @Override
   public GetClientStartTimeResult getClientStartTime(String clientKey) {
     try {
       return backplane.getClientStartTime(clientKey);

--- a/src/main/java/build/buildfarm/instance/stub/StubInstance.java
+++ b/src/main/java/build/buildfarm/instance/stub/StubInstance.java
@@ -853,6 +853,11 @@ public class StubInstance implements Instance {
   }
 
   @Override
+  public boolean needsToExpire() {
+    return false;
+  }
+
+  @Override
   public CasIndexResults reindexCas(String hostName) {
     throwIfStopped();
     ReindexCasRequestResults proto =

--- a/src/main/java/build/buildfarm/worker/DequeueMatchSettings.java
+++ b/src/main/java/build/buildfarm/worker/DequeueMatchSettings.java
@@ -22,12 +22,19 @@ package build.buildfarm.worker;
  */
 public class DequeueMatchSettings {
   /**
-   * @field acceptEverything
-   * @brief Whether or not the worker should accept everything it gets off the queue.
-   * @details This will assume the worker can always execute operations from the queue it matches
-   *     with.
+   * @field refuseWhenExpiringCas
+   * @brief Whether or not the worker should refuse operation when it is expiring the CAS.
+   * @details This can be enabled for performance reasons when the disk is being heavily utilized
+   *     from CAS expiration.
    */
-  public boolean acceptEverything = false;
+  public boolean refuseWhenExpiringCas = false;
+
+  /**
+   * @field refuseOnMismatchedProperties
+   * @brief Whether or not the worker should refuse operation when properties mismatch.
+   * @details This is generally not needed as the workers already match with the correct queue.
+   */
+  public boolean refuseOnMismatchedProperties = false;
 
   /**
    * @field allowUnmatched

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -312,7 +312,8 @@ class ShardWorkerContext implements WorkerContext {
     }
     listener.onWaitEnd();
 
-    if (DequeueMatchEvaluator.shouldKeepOperation(matchSettings, matchProvisions, queueEntry)) {
+    if (DequeueMatchEvaluator.shouldKeepOperation(
+        matchSettings, instance.needsToExpire(), matchProvisions, queueEntry)) {
       listener.onEntry(queueEntry);
     } else {
       backplane.rejectOperation(queueEntry);

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerInstance.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerInstance.java
@@ -365,6 +365,11 @@ public class ShardWorkerInstance extends AbstractServerInstance {
   }
 
   @Override
+  public boolean needsToExpire() {
+    return contentAddressableStorage.needsToExpire();
+  }
+
+  @Override
   protected Logger getLogger() {
     return logger;
   }

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -408,7 +408,10 @@ public class Worker extends LoggingMain {
     }
 
     DequeueMatchSettings matchSettings = new DequeueMatchSettings();
-    matchSettings.acceptEverything = config.getDequeueMatchSettings().getAcceptEverything();
+    matchSettings.refuseWhenExpiringCas =
+        config.getDequeueMatchSettings().getRefuseWhenExpiringCas();
+    matchSettings.refuseOnMismatchedProperties =
+        config.getDequeueMatchSettings().getRefuseOnMismatchedProperties();
     matchSettings.allowUnmatched = config.getDequeueMatchSettings().getAllowUnmatched();
 
     ShardWorkerContext context =

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -569,8 +569,11 @@ message ShardWorkerInstanceConfig {
 
 message DequeueMatchSettings {
   
-  // whether a worker should accept everything it gets off the queue.
-  bool accept_everything = 1;
+  // Whether or not the worker should refuse operation when it is expiring the CAS.
+  bool refuse_when_expiring_cas = 1;
+  
+  // Whether or not the worker should refuse operation when properties mismatch.
+  bool refuse_on_mismatched_properties = 4;
 
   // whether a worker should accept platform properties that it does not match with.
   bool allow_unmatched = 2;

--- a/src/test/java/build/buildfarm/instance/server/AbstractServerInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/server/AbstractServerInstanceTest.java
@@ -224,6 +224,11 @@ public class AbstractServerInstanceTest {
     public PrepareWorkerForGracefulShutDownRequestResults shutDownWorkerGracefully(String worker) {
       throw new UnsupportedOperationException();
     }
+
+    @Override
+    public boolean needsToExpire() {
+      throw new UnsupportedOperationException();
+    }
   }
 
   @Test

--- a/src/test/java/build/buildfarm/worker/DequeueMatchEvaluatorTest.java
+++ b/src/test/java/build/buildfarm/worker/DequeueMatchEvaluatorTest.java
@@ -49,12 +49,14 @@ public class DequeueMatchEvaluatorTest {
   public void shouldKeepOperationKeepEmptyQueueEntry() throws Exception {
     // ARRANGE
     DequeueMatchSettings settings = new DequeueMatchSettings();
+    settings.refuseOnMismatchedProperties = true;
+
     SetMultimap<String, String> workerProvisions = HashMultimap.create();
     QueueEntry entry = QueueEntry.newBuilder().setPlatform(Platform.newBuilder()).build();
 
     // ACT
     boolean shouldKeep =
-        DequeueMatchEvaluator.shouldKeepOperation(settings, workerProvisions, entry);
+        DequeueMatchEvaluator.shouldKeepOperation(settings, false, workerProvisions, entry);
 
     // ASSERT
     assertThat(shouldKeep).isTrue();
@@ -69,6 +71,7 @@ public class DequeueMatchEvaluatorTest {
   public void shouldKeepOperationValidMinCoresQueueEntry() throws Exception {
     // ARRANGE
     DequeueMatchSettings settings = new DequeueMatchSettings();
+    settings.refuseOnMismatchedProperties = true;
 
     SetMultimap<String, String> workerProvisions = HashMultimap.create();
     workerProvisions.put("cores", "11");
@@ -83,7 +86,7 @@ public class DequeueMatchEvaluatorTest {
 
     // ACT
     boolean shouldKeep =
-        DequeueMatchEvaluator.shouldKeepOperation(settings, workerProvisions, entry);
+        DequeueMatchEvaluator.shouldKeepOperation(settings, false, workerProvisions, entry);
 
     // ASSERT
     // the worker accepts because it has more cores than the min-cores requested
@@ -99,6 +102,7 @@ public class DequeueMatchEvaluatorTest {
   public void shouldKeepOperationInvalidMinCoresQueueEntry() throws Exception {
     // ARRANGE
     DequeueMatchSettings settings = new DequeueMatchSettings();
+    settings.refuseOnMismatchedProperties = true;
 
     SetMultimap<String, String> workerProvisions = HashMultimap.create();
     workerProvisions.put("cores", "10");
@@ -113,7 +117,7 @@ public class DequeueMatchEvaluatorTest {
 
     // ACT
     boolean shouldKeep =
-        DequeueMatchEvaluator.shouldKeepOperation(settings, workerProvisions, entry);
+        DequeueMatchEvaluator.shouldKeepOperation(settings, false, workerProvisions, entry);
 
     // ASSERT
     // the worker rejects because it has less cores than the min-cores requested
@@ -127,6 +131,7 @@ public class DequeueMatchEvaluatorTest {
   public void shouldKeepOperationMaxCoresDoNotInfluenceAcceptance() throws Exception {
     // ARRANGE
     DequeueMatchSettings settings = new DequeueMatchSettings();
+    settings.refuseOnMismatchedProperties = true;
 
     SetMultimap<String, String> workerProvisions = HashMultimap.create();
     workerProvisions.put("cores", "10");
@@ -143,7 +148,7 @@ public class DequeueMatchEvaluatorTest {
 
     // ACT
     boolean shouldKeep =
-        DequeueMatchEvaluator.shouldKeepOperation(settings, workerProvisions, entry);
+        DequeueMatchEvaluator.shouldKeepOperation(settings, false, workerProvisions, entry);
 
     // ASSERT
     // the worker accepts because it has the same cores as the min-cores requested
@@ -158,6 +163,7 @@ public class DequeueMatchEvaluatorTest {
   public void shouldKeepOperationUnmatchedPropertiesRejectionAcceptance() throws Exception {
     // ARRANGE
     DequeueMatchSettings settings = new DequeueMatchSettings();
+    settings.refuseOnMismatchedProperties = true;
 
     SetMultimap<String, String> workerProvisions = HashMultimap.create();
 
@@ -171,25 +177,17 @@ public class DequeueMatchEvaluatorTest {
 
     // ACT
     boolean shouldKeep =
-        DequeueMatchEvaluator.shouldKeepOperation(settings, workerProvisions, entry);
+        DequeueMatchEvaluator.shouldKeepOperation(settings, false, workerProvisions, entry);
 
     // ASSERT
     assertThat(shouldKeep).isFalse();
 
     // ARRANGE
-    settings.acceptEverything = true;
-
-    // ACT
-    shouldKeep = DequeueMatchEvaluator.shouldKeepOperation(settings, workerProvisions, entry);
-
-    // ASSERT
-    assertThat(shouldKeep).isTrue();
-
-    // ARRANGE
     settings.allowUnmatched = true;
 
     // ACT
-    shouldKeep = DequeueMatchEvaluator.shouldKeepOperation(settings, workerProvisions, entry);
+    shouldKeep =
+        DequeueMatchEvaluator.shouldKeepOperation(settings, false, workerProvisions, entry);
 
     // ASSERT
     assertThat(shouldKeep).isTrue();


### PR DESCRIPTION
The increased disk activity from cache expirations may cause performance to worsen for ongoing executions.  With this config enabled, workers can stop taking on work when they are expiring data,  and begin taking on work again once the expirations have finished.

I did not test this in a meaningful way, but sharing the idea. @80degreeswest / @jacobmou 