### PR TITLE
[refactor] move functionality out of getActionResult

### DIFF
--- a/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
@@ -344,6 +344,11 @@ public abstract class AbstractServerInstance implements Instance {
   public ListenableFuture<ActionResult> getActionResult(
       ActionKey actionKey, RequestMetadata requestMetadata) {
     ListenableFuture<ActionResult> result = checkNotNull(actionCache.get(actionKey));
+    return extendWithEnsureOutputsCheck(result, requestMetadata);
+  }
+
+  public ListenableFuture<ActionResult> extendWithEnsureOutputsCheck(
+      ListenableFuture<ActionResult> result, RequestMetadata requestMetadata) {
     if (shouldEnsureOutputsPresent(requestMetadata)) {
       result = checkNotNull(ensureOutputsPresent(result, requestMetadata));
     }


### PR DESCRIPTION
This change is part of https://github.com/bazelbuild/bazel-buildfarm/pull/943, but separating it here to make smaller diffs. 

I'd like `ShardInstance` to implement its own version of `getActionResult`, and that can be done more cleanly if it still leverages the existing EnsureOutputs code from the abstract class.  This change splits a function into two functions.