### PR TITLE
Downgrade log message with high spam rate

### DIFF
--- a/src/main/java/build/buildfarm/common/services/WriteStreamObserver.java
+++ b/src/main/java/build/buildfarm/common/services/WriteStreamObserver.java
@@ -291,6 +291,12 @@ public class WriteStreamObserver implements StreamObserver<WriteRequest> {
                 requestMetadata.getToolInvocationId(),
                 requestMetadata.getActionId(),
                 name));
+      } else if ("write cancelled".equals(t.getMessage())) {
+        log.log(
+            Level.FINE,
+            format(
+                "write cancelled for %s after %d requests and %d bytes at offset %d",
+                name, requestCount, requestBytes, earliestOffset));
       } else {
         log.log(
             Level.WARNING,


### PR DESCRIPTION
These log messages have a very high rate and are expected during cache expirations. Downgrade these to FINE to avoid spamming the logs.