### PR TITLE
ci: add multi-arch worker images

### DIFF
--- a/.github/workflows/buildfarm-worker-base-build-and-deploy.yml
+++ b/.github/workflows/buildfarm-worker-base-build-and-deploy.yml
@@ -1,4 +1,5 @@
 name: Build and Push Base Buildfarm Worker Images
+# Following the HOWTO at https://docs.docker.com/build/ci/github-actions/multi-platform/
 
 on:
   push:
@@ -14,7 +15,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        # QEMU needed for the ARM variant.
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        # Docker Buildx needed for the ARM variant.
 
       - name: Login to Bazelbuild Docker Hub
         uses: docker/login-action@v3
@@ -23,17 +32,19 @@ jobs:
           password: ${{ secrets.BAZELBUILD_DOCKERHUB_TOKEN }}
 
       - name: Build Jammy Docker image
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64/v8
           file: ./ci/base-worker-image/jammy/Dockerfile
           push: true
           tags: bazelbuild/buildfarm-worker-base:jammy
 
       - name: Build Mantic Docker image
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64/v8
           file: ./ci/base-worker-image/mantic/Dockerfile
           push: true
           tags: bazelbuild/buildfarm-worker-base:mantic

--- a/ci/base-worker-image/jammy/Dockerfile
+++ b/ci/base-worker-image/jammy/Dockerfile
@@ -1,6 +1,6 @@
 # A minimal container for building a base worker image.
 # Buildfarm public releases are build using this image as a starting point.
-FROM ubuntu:22.04
+FROM ubuntu:jammy-20240427@sha256:a6d2b38300ce017add71440577d5b0a90460d0e57fd7aec21dd0d1b0761bbfb2
 
 RUN apt-get update
 RUN apt-get -y install default-jre default-jdk build-essential libfuse2 cgroup-tools

--- a/ci/base-worker-image/mantic/Dockerfile
+++ b/ci/base-worker-image/mantic/Dockerfile
@@ -1,6 +1,6 @@
 # A minimal container for building a base worker image.
 # Buildfarm public releases are build using this image as a starting point.
-FROM ubuntu:23.04
+FROM ubuntu:mantic-20240427@sha256:565d62d2283a7cc4b3d759d9a97a5bfcebeb341166f9076a4df504f8f106cd54
 
 RUN apt-get update
 RUN apt-get -y install default-jre default-jdk build-essential libfuse2 cgroup-tools


### PR DESCRIPTION
Adding `linux/arm64/v8` variants for the worker images.

The GitHub Actions changes were based on https://docs.docker.com/build/ci/github-actions/multi-platform/ , QEMU and Docker Buildx needed for the ARM variant.

Also, bumping `ci-base-worker-image/mantic/Dockerfile` and `ci-base-worker-image/jammy/Dockerfile` (unused) to trigger a github action to run after merging to the default branch.