### PR TITLE
1787-Support_multiple_hash_functions

### DIFF
--- a/src/main/java/build/buildfarm/cas/BUILD
+++ b/src/main/java/build/buildfarm/cas/BUILD
@@ -19,6 +19,7 @@ java_library(
         "@com_google_googleapis//google/bytestream:bytestream_java_grpc",
         "@com_google_googleapis//google/bytestream:bytestream_java_proto",
         "@com_google_googleapis//google/rpc:rpc_java_proto",
+        "@maven//:com_github_ben_manes_caffeine_caffeine",
         "@maven//:com_github_jnr_jnr_ffi",
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_guava_guava",

--- a/src/main/java/build/buildfarm/cas/ContentAddressableStorage.java
+++ b/src/main/java/build/buildfarm/cas/ContentAddressableStorage.java
@@ -17,6 +17,7 @@ package build.buildfarm.cas;
 import build.bazel.remote.execution.v2.BatchReadBlobsResponse.Response;
 import build.bazel.remote.execution.v2.Compressor;
 import build.bazel.remote.execution.v2.Digest;
+import build.bazel.remote.execution.v2.DigestFunction;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import build.buildfarm.common.DigestUtil;
 import build.buildfarm.common.EntryLimitException;
@@ -100,6 +101,14 @@ public interface ContentAddressableStorage extends InputStreamFactory {
   Write getWrite(
       Compressor.Value compression, Digest digest, UUID uuid, RequestMetadata requestMetadata)
       throws EntryLimitException;
+
+  @Nullable
+  default Write getWrite(
+          Compressor.Value compression, Digest digest, DigestFunction.Value digestFunction,
+          UUID uuid, RequestMetadata requestMetadata)
+          throws EntryLimitException {
+    return null;
+  }
 
   /** Insert a blob into the CAS. */
   void put(Blob blob) throws InterruptedException;

--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -44,14 +44,8 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
+import build.bazel.remote.execution.v2.*;
 import build.bazel.remote.execution.v2.BatchReadBlobsResponse.Response;
-import build.bazel.remote.execution.v2.Compressor;
-import build.bazel.remote.execution.v2.Digest;
-import build.bazel.remote.execution.v2.Directory;
-import build.bazel.remote.execution.v2.DirectoryNode;
-import build.bazel.remote.execution.v2.FileNode;
-import build.bazel.remote.execution.v2.RequestMetadata;
-import build.bazel.remote.execution.v2.SymlinkNode;
 import build.buildfarm.cas.ContentAddressableStorage;
 import build.buildfarm.cas.DigestMismatchException;
 import build.buildfarm.common.BuildfarmExecutors;
@@ -71,6 +65,8 @@ import build.buildfarm.common.io.FeedbackOutputStream;
 import build.buildfarm.common.io.FileStatus;
 import build.buildfarm.common.io.NamedFileKey;
 import build.buildfarm.v1test.BlobWriteKey;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.common.cache.CacheBuilder;
@@ -247,6 +243,13 @@ public abstract class CASFileCache implements ContentAddressableStorage {
   private final transient Entry header = new SentinelEntry();
   private volatile long unreferencedEntryCount = 0;
 
+  private static final int MAX_ENTRIES = 10000;
+  private static final Cache<String, DigestFunction.Value> digest_to_function_map =
+          Caffeine.newBuilder()
+                  .expireAfterWrite(2, TimeUnit.MINUTES)
+                  .maximumSize(MAX_ENTRIES)
+                  .build();
+
   @GuardedBy("this")
   private long removedEntrySize = 0;
 
@@ -375,7 +378,8 @@ public abstract class CASFileCache implements ContentAddressableStorage {
 
     String hashComponent = components[0];
 
-    return digestUtil.build(hashComponent, size);
+    DigestUtil corrDigestUtil = DigestUtil.forDigestFunction(digest_to_function_map.getIfPresent(hashComponent));
+    return corrDigestUtil.build(hashComponent, size);
   }
 
   /**
@@ -775,7 +779,8 @@ public abstract class CASFileCache implements ContentAddressableStorage {
 
   @Override
   public Write getWrite(
-      Compressor.Value compressor, Digest digest, UUID uuid, RequestMetadata requestMetadata)
+      Compressor.Value compressor, Digest digest, DigestFunction.Value digestFunction,
+      UUID uuid, RequestMetadata requestMetadata)
       throws EntryLimitException {
     if (digest.getSizeBytes() == 0) {
       return new CompleteWrite(0);
@@ -787,6 +792,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
       return writes.get(
           BlobWriteKey.newBuilder()
               .setDigest(digest)
+              .setDigestFunction(digestFunction)
               .setIdentifier(uuid.toString())
               .setCompressor(compressor)
               .build());
@@ -981,6 +987,8 @@ public abstract class CASFileCache implements ContentAddressableStorage {
               throws IOException {
             // caller will be the exclusive owner of this write stream. all other requests
             // will block until it is returned via a close.
+            // Map identifier to digest function
+            digest_to_function_map.put(key.getDigest().getHash(), key.getDigestFunction());
             if (closedFuture != null) {
               try {
                 while (!closedFuture.isDone()) {
@@ -2861,6 +2869,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
     Path writePath = getPath(key).resolveSibling(writeKey);
     final long committedSize;
     HashingOutputStream hashOut;
+    DigestUtil corrDigestUtil = DigestUtil.forDigestFunction(digest_to_function_map.getIfPresent(key));
     if (!isReset && Files.exists(writePath)) {
       committedSize = Files.size(writePath);
       try (InputStream in = Files.newInputStream(writePath)) {
@@ -2869,14 +2878,14 @@ public abstract class CASFileCache implements ContentAddressableStorage {
         // open
         SkipOutputStream skipStream =
             new SkipOutputStream(Files.newOutputStream(writePath, APPEND), committedSize);
-        hashOut = digestUtil.newHashingOutputStream(skipStream);
+        hashOut = corrDigestUtil.newHashingOutputStream(skipStream);
         ByteStreams.copy(in, hashOut);
         in.close();
         checkState(skipStream.isSkipped());
       }
     } else {
       committedSize = 0;
-      hashOut = digestUtil.newHashingOutputStream(Files.newOutputStream(writePath, CREATE));
+      hashOut = corrDigestUtil.newHashingOutputStream(Files.newOutputStream(writePath, CREATE));
     }
     Supplier<String> hashSupplier = () -> hashOut.hash().toString();
     CountingOutputStream countingOut = new CountingOutputStream(committedSize, hashOut);

--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -244,7 +244,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
   private volatile long unreferencedEntryCount = 0;
 
   private static final int MAX_ENTRIES = 10000;
-  private static final Cache<String, DigestFunction.Value> digest_to_function_map =
+  private static final Cache<String, DigestFunction.Value> digestToFunctionMap =
           Caffeine.newBuilder()
                   .expireAfterWrite(2, TimeUnit.MINUTES)
                   .maximumSize(MAX_ENTRIES)
@@ -378,7 +378,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
 
     String hashComponent = components[0];
 
-    DigestUtil corrDigestUtil = DigestUtil.forDigestFunction(digest_to_function_map.getIfPresent(hashComponent));
+    DigestUtil corrDigestUtil = DigestUtil.forDigestFunction(digestToFunctionMap.getIfPresent(hashComponent));
     return corrDigestUtil.build(hashComponent, size);
   }
 
@@ -988,7 +988,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
             // caller will be the exclusive owner of this write stream. all other requests
             // will block until it is returned via a close.
             // Map identifier to digest function
-            digest_to_function_map.put(key.getDigest().getHash(), key.getDigestFunction());
+            digestToFunctionMap.put(key.getDigest().getHash(), key.getDigestFunction());
             if (closedFuture != null) {
               try {
                 while (!closedFuture.isDone()) {
@@ -2869,7 +2869,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
     Path writePath = getPath(key).resolveSibling(writeKey);
     final long committedSize;
     HashingOutputStream hashOut;
-    DigestUtil corrDigestUtil = DigestUtil.forDigestFunction(digest_to_function_map.getIfPresent(key));
+    DigestUtil corrDigestUtil = DigestUtil.forDigestFunction(digestToFunctionMap.getIfPresent(key));
     if (!isReset && Files.exists(writePath)) {
       committedSize = Files.size(writePath);
       try (InputStream in = Files.newInputStream(writePath)) {

--- a/src/main/java/build/buildfarm/common/BUILD
+++ b/src/main/java/build/buildfarm/common/BUILD
@@ -80,6 +80,20 @@ java_library(
     ],
 )
 
+java_library(
+    name = "digestUtil",
+    srcs = ["DigestUtil.java"],
+    plugins = [":lombok"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/main/java/build/buildfarm/common/blake3",
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:org_projectlombok_lombok",
+        "@remoteapis//build/bazel/remote/execution/v2:remote_execution_java_proto",
+    ],
+)
+
 java_plugin(
     name = "lombok",
     generates_api = True,

--- a/src/main/java/build/buildfarm/common/DigestUtil.java
+++ b/src/main/java/build/buildfarm/common/DigestUtil.java
@@ -33,7 +33,9 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import lombok.Getter;
 
@@ -164,6 +166,12 @@ public class DigestUtil {
 
   public DigestFunction.Value getDigestFunction() {
     return hashFn.getDigestFunction();
+  }
+
+  public static List<DigestFunction.Value> getSupportedDigestFunctions() {
+    return Stream.of(HashFunction.values())
+        .map(HashFunction::getDigestFunction)
+        .toList();
   }
 
   public Digest compute(Path file) throws IOException {

--- a/src/main/java/build/buildfarm/common/resources/BUILD
+++ b/src/main/java/build/buildfarm/common/resources/BUILD
@@ -28,6 +28,7 @@ java_library(
     srcs = ["ResourceParser.java"],
     visibility = ["//visibility:public"],
     deps = [
+        "//src/main/java/build/buildfarm/common:digestUtil",
         "//src/main/java/build/buildfarm/common/resources:resource_java_proto",
         "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
         "@com_google_googleapis//google/longrunning:longrunning_java_proto",

--- a/src/main/java/build/buildfarm/common/resources/ResourceParser.java
+++ b/src/main/java/build/buildfarm/common/resources/ResourceParser.java
@@ -17,6 +17,7 @@ package build.buildfarm.common.resources;
 import build.bazel.remote.execution.v2.Compressor;
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.DigestFunction;
+import build.buildfarm.common.DigestUtil;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
@@ -308,6 +309,11 @@ public class ResourceParser {
     if (DIGEST_FUNCTIONS.containsKey(maybeDigestFunction)) {
       builder.setDigestFunction(DIGEST_FUNCTIONS.get(maybeDigestFunction));
       index.getAndIncrement();
+    } else {
+      // Infer the digest function based on the hash format
+      // Should go here when it's not BLAKE3
+      String hash = maybeDigestFunction;
+      builder.setDigestFunction(DigestUtil.HashFunction.forHash(hash).getDigestFunction());
     }
     String hash = segments[index.getAndIncrement()];
     String size = segments[index.getAndIncrement()];

--- a/src/main/java/build/buildfarm/instance/server/NodeInstance.java
+++ b/src/main/java/build/buildfarm/instance/server/NodeInstance.java
@@ -1898,7 +1898,7 @@ public abstract class NodeInstance implements Instance {
 
   protected CacheCapabilities getCacheCapabilities() {
     return CacheCapabilities.newBuilder()
-        .addAllDigestFunctions(Arrays.asList(DigestFunction.Value.BLAKE3, DigestFunction.Value.SHA256, DigestFunction.Value.SHA1, DigestFunction.Value.MD5))
+        .addAllDigestFunctions(DigestUtil.getSupportedDigestFunctions())
         .setActionCacheUpdateCapabilities(
             ActionCacheUpdateCapabilities.newBuilder().setUpdateEnabled(true))
         .setMaxBatchTotalSizeBytes(Size.mbToBytes(4))

--- a/src/main/java/build/buildfarm/instance/server/NodeInstance.java
+++ b/src/main/java/build/buildfarm/instance/server/NodeInstance.java
@@ -123,12 +123,7 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.NoSuchFileException;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.Stack;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -410,10 +405,7 @@ public abstract class NodeInstance implements Instance {
       UUID uuid,
       RequestMetadata requestMetadata)
       throws EntryLimitException {
-    Preconditions.checkState(
-        digestFunction == DigestFunction.Value.UNKNOWN
-            || digestFunction == digestUtil.getDigestFunction());
-    return contentAddressableStorage.getWrite(compressor, digest, uuid, requestMetadata);
+    return contentAddressableStorage.getWrite(compressor, digest, digestFunction, uuid, requestMetadata);
   }
 
   @Override
@@ -1906,7 +1898,7 @@ public abstract class NodeInstance implements Instance {
 
   protected CacheCapabilities getCacheCapabilities() {
     return CacheCapabilities.newBuilder()
-        .addDigestFunctions(digestUtil.getDigestFunction())
+        .addAllDigestFunctions(Arrays.asList(DigestFunction.Value.BLAKE3, DigestFunction.Value.SHA256, DigestFunction.Value.SHA1, DigestFunction.Value.MD5))
         .setActionCacheUpdateCapabilities(
             ActionCacheUpdateCapabilities.newBuilder().setUpdateEnabled(true))
         .setMaxBatchTotalSizeBytes(Size.mbToBytes(4))

--- a/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
@@ -1339,9 +1339,6 @@ public class ServerInstance extends NodeInstance {
       UUID uuid,
       RequestMetadata requestMetadata)
       throws EntryLimitException {
-    checkState(
-        digestFunction == DigestFunction.Value.UNKNOWN
-            || digestFunction == digestUtil.getDigestFunction());
     try {
       if (inDenyList(requestMetadata)) {
         throw Status.UNAVAILABLE.withDescription(BLOCK_LIST_ERROR).asRuntimeException();

--- a/src/main/java/build/buildfarm/worker/shard/ShardCASFileCache.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardCASFileCache.java
@@ -16,15 +16,20 @@ package build.buildfarm.worker.shard;
 
 import build.bazel.remote.execution.v2.Compressor;
 import build.bazel.remote.execution.v2.Digest;
+import build.bazel.remote.execution.v2.RequestMetadata;
 import build.buildfarm.cas.ContentAddressableStorage;
 import build.buildfarm.cas.cfc.CASFileCache;
 import build.buildfarm.common.DigestUtil;
+import build.buildfarm.common.EntryLimitException;
 import build.buildfarm.common.InputStreamFactory;
+import build.buildfarm.common.Write;
 import build.buildfarm.common.ZstdDecompressingOutputStream.FixedBufferPool;
 import com.google.common.collect.Maps;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.util.UUID;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
@@ -87,5 +92,10 @@ class ShardCASFileCache extends CASFileCache {
   protected InputStream newExternalInput(Compressor.Value compressor, Digest digest, long offset)
       throws IOException {
     return inputStreamFactory.newInput(compressor, digest, offset);
+  }
+
+  @Override
+  public Write getWrite(Compressor.Value compression, Digest digest, UUID uuid, RequestMetadata requestMetadata) throws EntryLimitException {
+    return null;
   }
 }

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -568,6 +568,8 @@ message BlobWriteKey {
   string identifier = 2;
 
   build.bazel.remote.execution.v2.Compressor.Value compressor = 3;
+
+  build.bazel.remote.execution.v2.DigestFunction.Value digest_function = 4;
 }
 
 message OperationTimesBetweenStages {


### PR DESCRIPTION
Feature to support multiple Hash Functions as described [here](https://github.com/bazelbuild/bazel-buildfarm/issues/1787).

Some uncertain parts I expressed in comments now. Once discussed I will remove those and adjust the unit tests before a potential merge .