### PR TITLE
allowedUnmatched not working as expected.

### DIFF
--- a/src/main/java/build/buildfarm/worker/DequeueMatchEvaluator.java
+++ b/src/main/java/build/buildfarm/worker/DequeueMatchEvaluator.java
@@ -153,13 +153,18 @@ public class DequeueMatchEvaluator {
       return possibleMemories >= memBytesRequested;
     }
 
+    if (configs.getWorker().getDequeueMatchSettings().isAllowUnmatched()) {
+      // accept other properties not specified on the worker
+      return true;
+    }
+    
     // ensure exact matches
     if (workerProvisions.containsKey(property.getName())) {
       return workerProvisions.containsEntry(property.getName(), property.getValue())
           || workerProvisions.containsEntry(property.getName(), "*");
     }
 
-    // accept other properties not specified on the worker
-    return configs.getWorker().getDequeueMatchSettings().isAllowUnmatched();
+    
+    return false;
   }
 }


### PR DESCRIPTION
We have an unusual bug in our buildfarm deploy. Some product-teams send us "OSFamily" and "Linux" and this does NOT match "OSFamily" and "Linux" in the queue configuration used by servers or workers. 

Examples:
```
  queues:
    - name: "*"
      allowUnmatched: true
    - name: "default"
      allowUnmatched: true
      properties:
        - name: "OSFamily"
          value: "*"
    - name: "linux"
      allowUnmatched: true
      properties:
        - name: "min-cores"
          value: "*"
        - name: "max-cores"
          value: "*"
        - name: "OSFamily"
          value: "Linux"
```

Even with all three queues defined, the client is seeing 
```
(INVALID) The `Platform` of the `Command` was invalid.: properties are not valid for queue eligibility: [name: "OSFamily"
value: "Linux"
].
```

Conjectures:
* Is a hidden char in the "Linux" string is making it into an upstream OSS project's actions from the Bazel side of the conversation?
* Is a charset difference between the Bazel and BuildFarm service present and causing a mismatch?
* Is the character `*` used on the service/worker side configuration from a different alphabet than the one in the JDK?

Either way, rearranging the order of the checks produces the desired effect and the client no longer receives the error that "Linux" does not equal "Linux" ... still ... it would be nice to specify "Linux" and have it match "Linux"

Is this as intended? Should `allowUnmatched: true` refuse to match when the properties don't match?
