### PR TITLE
Chore: update ci image

### DIFF
--- a/.bazelci/ingest_grpc_logs.py
+++ b/.bazelci/ingest_grpc_logs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 import json
 import time
 import sys

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -89,7 +89,7 @@ tasks:
   # Outside of this step, similar functionality may be tested with mocks.
   redis_unit_tests:
     name: "Redis Unit Tests"
-    platform: ubuntu2004
+    platform: ubuntu2204
     shell_commands:
     - ./.bazelci/redis_unit_tests.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
 # A minimal container for building and running buildfarm services.
 # We copy in the current state of the reposiory to test against PR changes.
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 # For network stability we allow apt-get to retry.
 # The "80" is required for config priority but its not specifically important.
 RUN echo 'APT::Acquire::Retries "5";' > /etc/apt/apt.conf.d/80retries
 
 RUN apt-get update
-RUN apt-get -y install wget git zip python gcc openjdk-8-jdk g++ redis redis-server
-RUN wget --tries=10 -O get-pip.py https://bootstrap.pypa.io/pip/2.7/get-pip.py
-RUN python2 get-pip.py
-RUN pip install python-dateutil==2.8.2
+RUN apt-get -y install git zip python3 python3-pip gcc openjdk-21-jdk g++ redis redis-server
+
+RUN pip3 install python-dateutil==2.9.0.post0
 COPY . buildfarm


### PR DESCRIPTION
remove references to ubuntu:2004 (code named "Focal", released in 2020) and replace with Ubuntu `2204` aka 22.04 aka Jammy