### PR TITLE
Add build.buildfarm logger config to example logging.properties

### DIFF
--- a/examples/logging.properties
+++ b/examples/logging.properties
@@ -1,3 +1,5 @@
+build.buildfarm.level=FINE
+
 handlers=java.util.logging.ConsoleHandler
 java.util.logging.ConsoleHandler.level=FINE
 java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter


### PR DESCRIPTION
When experimenting with BF locally it took me some time to figure out why I wasn't getting more detailed logs when increasing the log level of `java.util.logging.ConsoleHandler.level`. I'd missed that I needed to also adjust the log level for the `build.buildfarm` namespace itself.

I assume operators customize their own logging configs anyway if they care to, but I thought this might be useful to add to the example config so that it shows FINE-level logs and so that anyone else just running a test setup locally has a bit of an easier time with adjusting log levels.

Thanks!