### PR TITLE
Changed handling of JedisException in RedisShardSubscription::stop

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/RedisShardSubscription.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardSubscription.java
@@ -72,6 +72,12 @@ class RedisShardSubscription implements Runnable {
   }
 
   class SubscriptionAutoCloseable implements AutoCloseable {
+    public void initiateSubscription() {
+      SettableFuture subscribeFuture = SettableFuture.create();
+      subscriber.setSubscribeFuture(subscribeFuture);
+      manageState(SubscriptionAction.START_SUBSCRIBE);
+    }
+
     @Override
     public void close() {
       subscriber.setSubscribeFuture(null);
@@ -113,9 +119,9 @@ class RedisShardSubscription implements Runnable {
     }
 
     try (SubscriptionAutoCloseable subscriptionAutoCloseable = new SubscriptionAutoCloseable()) {
-      SettableFuture subscribeFuture = SettableFuture.create();
-      subscriber.setSubscribeFuture(subscribeFuture);
-      manageState(SubscriptionAction.START_SUBSCRIBE);
+
+      subscriptionAutoCloseable.initiateSubscription();
+
       if (subscriptionState.get() == SubscriptionState.SUBSCRIBING) {
         jedis.subscribe(subscriber, subscriptions.get().toArray(new String[0]));
       } else {

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardSubscription.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardSubscription.java
@@ -118,35 +118,26 @@ class RedisShardSubscription implements Runnable {
 
   public void stop() {
     manageState(SubscriptionAction.STOP);
-    if (attemptingSubscripton.get()) {
-      try {
-        subscriber.unsubscribe();
-      } catch (JedisException e) {
-        // If stop() is called before a connection is established, log and throw the exception
-        if (e.getMessage().endsWith(" is not connected to a Connection.")) {
-          log.log(
-              Level.SEVERE,
-              "RedisShardSubscription::stop called but no connection is established. "
-                  + "Subscription is now in 'Stopped' state and cannot subscribe.");
-        }
-        throw e;
-      } finally {
-        if (attemptingSubscripton.get()) {
-          try {
-            Thread.sleep(10);
-          } catch (InterruptedException e) {
-            e.printStackTrace();
-          }
-          stop();
-        }
+    try {
+      subscriber.unsubscribe();
+    } catch (JedisException e) {
+      // If stop() is called before a connection is established, log and throw the exception
+      if (e.getMessage().endsWith(" is not connected to a Connection.")) {
+        log.log(
+            Level.SEVERE,
+            "RedisShardSubscription::stop called but no connection is established. "
+                + "Subscription is now in 'Stopped' state and cannot subscribe.");
       }
-    }
-    // No attempt to subscribe, alert the user and return
-    else {
-      log.log(
-          Level.SEVERE,
-          "RedisShardSubscription::stop called but no connection is established. "
-              + "Subscription is now in 'Stopped' state and cannot subscribe.");
+      throw e;
+    } finally {
+      if (attemptingSubscripton.get()) {
+        try {
+          Thread.sleep(10);
+        } catch (InterruptedException e) {
+          e.printStackTrace();
+        }
+        stop();
+      }
     }
   }
 

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardSubscription.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardSubscription.java
@@ -87,7 +87,7 @@ class RedisShardSubscription implements Runnable {
     }
   }
 
-  public void stop() throws JedisException {
+  public void stop() {
     if (stopped.compareAndSet(false, true)) {
       try {
         subscriber.unsubscribe();
@@ -98,8 +98,8 @@ class RedisShardSubscription implements Runnable {
               Level.SEVERE,
               "RedisShardSubscription::stop called but no connection is established. "
                   + "Subscription is now in 'Stopped' state and cannot subscribe.");
-          throw e;
         }
+        throw e;
       }
     }
   }

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardSubscription.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardSubscription.java
@@ -87,14 +87,15 @@ class RedisShardSubscription implements Runnable {
     }
   }
 
-  public void stop() {
+  public void stop() throws JedisException{
     if (stopped.compareAndSet(false, true)) {
       try {
         subscriber.unsubscribe();
       } catch (JedisException e) {
-        // subscriber validates with private member to determine connection status
-        // detect this condition and ignore it
-        if (!e.getMessage().endsWith(" is not connected to a Connection.")) {
+        // If stop() is called before a connection is established, log and throw the exception
+        if (e.getMessage().endsWith(" is not connected to a Connection.")) {
+          log.log(Level.SEVERE, "RedisShardSubscription::stop called but no connection is established. " +
+                  "Subscription is now in 'Stopped' state and cannot subscribe.");
           throw e;
         }
       }

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardSubscription.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardSubscription.java
@@ -87,15 +87,17 @@ class RedisShardSubscription implements Runnable {
     }
   }
 
-  public void stop() throws JedisException{
+  public void stop() throws JedisException {
     if (stopped.compareAndSet(false, true)) {
       try {
         subscriber.unsubscribe();
       } catch (JedisException e) {
         // If stop() is called before a connection is established, log and throw the exception
         if (e.getMessage().endsWith(" is not connected to a Connection.")) {
-          log.log(Level.SEVERE, "RedisShardSubscription::stop called but no connection is established. " +
-                  "Subscription is now in 'Stopped' state and cannot subscribe.");
+          log.log(
+              Level.SEVERE,
+              "RedisShardSubscription::stop called but no connection is established. "
+                  + "Subscription is now in 'Stopped' state and cannot subscribe.");
           throw e;
         }
       }

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardSubscription.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardSubscription.java
@@ -21,36 +21,43 @@ import build.buildfarm.common.redis.RedisClient;
 import io.grpc.Status;
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import lombok.extern.java.Log;
-import redis.clients.jedis.JedisPubSub;
 import redis.clients.jedis.UnifiedJedis;
 import redis.clients.jedis.exceptions.JedisException;
 
 @Log
 class RedisShardSubscription implements Runnable {
-  private final JedisPubSub subscriber;
+  private final RedisShardSubscriber subscriber;
   private final InterruptingRunnable onUnsubscribe;
   private final Consumer<UnifiedJedis> onReset;
   private final Supplier<List<String>> subscriptions;
   private final RedisClient client;
-  private final AtomicBoolean stopped = new AtomicBoolean(false);
-  private final AtomicBoolean attemptingSubscription = new AtomicBoolean(false);
-
-  public static final int SUBSCRIBE_POLL_PERIOD = 1;
 
   private enum SubscriptionAction {
     STOP,
     START_SUBSCRIBE,
-    COMPLETE_SUBSCRIBE
+    END_SUBSCRIPTION
   }
 
+  private enum SubscriptionState {
+    NOT_SUBSCRIBED,
+    SUBSCRIBING,
+    SUBSCRIBED,
+    STOPPED_BUT_SUBSCRIBED,
+    FULLY_STOPPED
+  }
+
+  private final AtomicReference<SubscriptionState> subscriptionState =
+      new AtomicReference<>(SubscriptionState.NOT_SUBSCRIBED);
+
   RedisShardSubscription(
-      JedisPubSub subscriber,
+      RedisShardSubscriber subscriber,
       InterruptingRunnable onUnsubscribe,
       Consumer<UnifiedJedis> onReset,
       Supplier<List<String>> subscriptions,
@@ -63,17 +70,29 @@ class RedisShardSubscription implements Runnable {
   }
 
   private synchronized void manageState(SubscriptionAction update) {
+    SubscriptionState currentState = subscriptionState.get();
     switch (update) {
       case STOP:
-        stopped.set(true);
-        break;
-      case START_SUBSCRIBE:
-        if (!stopped.get()) {
-          attemptingSubscription.set(true);
+        if (currentState == SubscriptionState.NOT_SUBSCRIBED) {
+          subscriptionState.set(SubscriptionState.FULLY_STOPPED);
+        } else if (currentState == SubscriptionState.SUBSCRIBING
+            || currentState == SubscriptionState.SUBSCRIBED) {
+          subscriptionState.set(SubscriptionState.STOPPED_BUT_SUBSCRIBED);
         }
         break;
-      case COMPLETE_SUBSCRIBE:
-        attemptingSubscription.set(false);
+      case START_SUBSCRIBE:
+        if (currentState != SubscriptionState.STOPPED_BUT_SUBSCRIBED
+            && currentState != SubscriptionState.FULLY_STOPPED) {
+          subscriptionState.set(SubscriptionState.SUBSCRIBING);
+        }
+        break;
+      case END_SUBSCRIPTION:
+        if (currentState == SubscriptionState.STOPPED_BUT_SUBSCRIBED
+            || currentState == SubscriptionState.FULLY_STOPPED) {
+          subscriptionState.set(SubscriptionState.FULLY_STOPPED);
+        } else {
+          subscriptionState.set(SubscriptionState.NOT_SUBSCRIBED);
+        }
         break;
     }
   }
@@ -83,11 +102,15 @@ class RedisShardSubscription implements Runnable {
       onReset.accept(jedis);
     }
     manageState(SubscriptionAction.START_SUBSCRIBE);
-    if (attemptingSubscription.get()) {
+    if (subscriptionState.get() == SubscriptionState.SUBSCRIBING) {
       jedis.subscribe(subscriber, subscriptions.get().toArray(new String[0]));
-      manageState(SubscriptionAction.COMPLETE_SUBSCRIBE);
+      manageState(SubscriptionAction.END_SUBSCRIPTION);
     } else {
-      log.log(Level.SEVERE, "Cannot subscribe, RedisShardSubscription is in 'stopped' state");
+      log.log(
+          Level.SEVERE,
+          "Cannot subscribe, RedisShardSubscription is in 'stopped' state "
+              + subscriptionState.get().name());
+      manageState(SubscriptionAction.END_SUBSCRIPTION);
     }
   }
 
@@ -100,6 +123,7 @@ class RedisShardSubscription implements Runnable {
         case DEADLINE_EXCEEDED:
         case UNAVAILABLE:
           log.log(Level.WARNING, "failed to subscribe", formatIOError(e));
+          manageState(SubscriptionAction.END_SUBSCRIPTION);
           /* ignore */
           break;
         default:
@@ -110,7 +134,8 @@ class RedisShardSubscription implements Runnable {
 
   private void mainLoop() throws IOException {
     boolean first = true;
-    while (!stopped.get()) {
+    while (subscriptionState.get() != SubscriptionState.STOPPED_BUT_SUBSCRIBED
+        && subscriptionState.get() != SubscriptionState.FULLY_STOPPED) {
       if (!first) {
         log.log(Level.SEVERE, "unexpected subscribe return, reconnecting...");
       }
@@ -122,26 +147,24 @@ class RedisShardSubscription implements Runnable {
   public void stop(long timeoutMillis) {
     manageState(SubscriptionAction.STOP);
     try {
-      long startTimeMillis = System.currentTimeMillis();
-      while (attemptingSubscription.get() && !subscriber.isSubscribed()) {
+      if (subscriptionState.get() == SubscriptionState.STOPPED_BUT_SUBSCRIBED) {
         try {
-          TimeUnit.MILLISECONDS.sleep(SUBSCRIBE_POLL_PERIOD);
-        } catch (InterruptedException intEx) {
-          log.log(
-              Level.SEVERE,
-              "Call to stop subscription was interrupted before unsubscribing. "
-                  + "JedisPubSub subscriber is still active");
-        }
-
-        if (System.currentTimeMillis() - startTimeMillis > timeoutMillis) {
+          subscriber.checkIfSubscribed(timeoutMillis);
+        } catch (TimeoutException e) {
           throw new UnsubscribeTimeoutException(
-              "Call to stop subscription timed out while waiting for JedisPubSub::subscribe to"
-                  + " complete. Subscriber is still active.");
+              "Call to stop subscription timed out while waiting for"
+                  + " RedisShardSubscriber::subscribe to complete. Subscriber is still active.");
+        } catch (InterruptedException | ExecutionException e) {
+          throw new UnsubscribeException(
+              "Call to stop subscription was interrupted or errored before unsubscribing. "
+                  + "Subscriber is still active. \n"
+                  + "Exception message: "
+                  + e.getMessage());
         }
       }
       subscriber.unsubscribe();
     } catch (JedisException e) {
-      // If stop() is called before a connection is established, log and throw the exception
+      // If stop() is called without an established connection, log and throw the exception
       if (e.getMessage().endsWith(" is not connected to a Connection.")) {
         log.log(
             Level.SEVERE,

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardSubscription.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardSubscription.java
@@ -55,6 +55,7 @@ class RedisShardSubscription implements Runnable {
 
   private final AtomicReference<SubscriptionState> subscriptionState =
       new AtomicReference<>(SubscriptionState.NOT_SUBSCRIBED);
+  private static final long DEFAULT_STOP_TIMEOUT = 1000;
 
   RedisShardSubscription(
       RedisShardSubscriber subscriber,
@@ -176,7 +177,7 @@ class RedisShardSubscription implements Runnable {
   }
 
   public void stop() {
-    stop(1000);
+    stop(DEFAULT_STOP_TIMEOUT);
   }
 
   @Override

--- a/src/main/java/build/buildfarm/instance/shard/UnsubscribeException.java
+++ b/src/main/java/build/buildfarm/instance/shard/UnsubscribeException.java
@@ -1,0 +1,21 @@
+// Copyright 2024 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.instance.shard;
+
+public class UnsubscribeException extends RuntimeException {
+  public UnsubscribeException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/build/buildfarm/instance/shard/UnsubscribeTimeoutException.java
+++ b/src/main/java/build/buildfarm/instance/shard/UnsubscribeTimeoutException.java
@@ -1,0 +1,21 @@
+// Copyright 2024 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.instance.shard;
+
+public class UnsubscribeTimeoutException extends RuntimeException {
+  public UnsubscribeTimeoutException(String message) {
+    super(message);
+  }
+}

--- a/src/test/java/build/buildfarm/instance/shard/RedisShardSubscriptionTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/RedisShardSubscriptionTest.java
@@ -92,12 +92,7 @@ public class RedisShardSubscriptionTest {
             .start();
     SettableFuture<Void> subscribed = SettableFuture.create();
     JedisPubSub subscriber =
-        new JedisPubSub() {
-          @Override
-          public void onSubscribe(String channel, int subscribedChannels) {
-            System.out.println("onSubscribe called");
-          }
-        };
+        new JedisPubSub() {};
     InterruptingRunnable onUnsubscribe = mock(InterruptingRunnable.class);
     Consumer<UnifiedJedis> onReset = mock(Consumer.class);
     doAnswer(

--- a/src/test/java/build/buildfarm/instance/shard/RedisShardSubscriptionTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/RedisShardSubscriptionTest.java
@@ -91,8 +91,7 @@ public class RedisShardSubscriptionTest {
                     }))
             .start();
     SettableFuture<Void> subscribed = SettableFuture.create();
-    JedisPubSub subscriber =
-        new JedisPubSub() {};
+    JedisPubSub subscriber = new JedisPubSub() {};
     InterruptingRunnable onUnsubscribe = mock(InterruptingRunnable.class);
     Consumer<UnifiedJedis> onReset = mock(Consumer.class);
     doAnswer(

--- a/src/test/java/build/buildfarm/instance/shard/RedisShardSubscriptionTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/RedisShardSubscriptionTest.java
@@ -68,11 +68,15 @@ public class RedisShardSubscriptionTest {
     RedisShardSubscription subscription =
         new RedisShardSubscription(
             redisSubscriber, onUnsubscribe, onReset, () -> subscriptions, new RedisClient(jedis));
+    final long subscribeCheckTime = 100;
 
     Thread thread = new Thread(subscription);
     thread.start();
 
-    redisSubscriber.checkIfSubscribed(1000);
+    while (!redisSubscriber.checkIfSubscribed(subscribeCheckTime)) {
+      Thread.yield();
+    }
+
     subscription.stop();
 
     thread.join();

--- a/src/test/java/build/buildfarm/instance/shard/RedisShardSubscriptionTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/RedisShardSubscriptionTest.java
@@ -15,6 +15,8 @@
 package build.buildfarm.instance.shard;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -93,11 +95,18 @@ public class RedisShardSubscriptionTest {
         new JedisPubSub() {
           @Override
           public void onSubscribe(String channel, int subscribedChannels) {
-            subscribed.set(null);
+            System.out.println("onSubscribe called");
           }
         };
     InterruptingRunnable onUnsubscribe = mock(InterruptingRunnable.class);
     Consumer<UnifiedJedis> onReset = mock(Consumer.class);
+    doAnswer(
+            invocation -> {
+              subscribed.set(null);
+              return null;
+            })
+        .when(onReset)
+        .accept(any(UnifiedJedis.class));
     List<String> subscriptions = ImmutableList.of("test");
     UnifiedJedis jedis = new UnifiedJedis(new HostAndPort(server.getHost(), server.getBindPort()));
 


### PR DESCRIPTION
fixes #1838 

If a call to `stop()` is made before any connection is established, the resulting JedisException will be thrown. 

Previously this exception was caught and swallowed, but this caused an issue where subscribe would never complete and the user would not be notified. Because the `stopped` Atomic Boolean is set at the beginning of the `stop()` method, the `mainLoop()` method would stop regardless of wether or not `unsubscribe()` could complete gracefully.

This change will throw an error in that case, to alert the user that the RedisSubscription object is now in "stopped" state and cannot accept connections.

The attached image shows how the race condition happens - by the time the initial call to `run()` progresses to the `mainLoop()` method, `stopped` is already set to true, and so `iterate()` is never called and the subscription is never connected. 

![stop-start redis race condition](https://github.com/user-attachments/assets/a0afa9d0-fc5d-4e75-af72-6614aaa25225)
