### PR TITLE
Pipelined BackplaneStatus

### DIFF
--- a/src/main/java/build/buildfarm/common/Queue.java
+++ b/src/main/java/build/buildfarm/common/Queue.java
@@ -1,6 +1,8 @@
 package build.buildfarm.common;
 
 import java.time.Duration;
+import java.util.function.Supplier;
+import redis.clients.jedis.AbstractPipeline;
 
 public interface Queue<E> {
   // java.util.BlockingQueue-ish
@@ -16,6 +18,8 @@ public interface Queue<E> {
 
   // java.util.Collection
   long size();
+
+  Supplier<Long> size(AbstractPipeline pipeline);
 
   // maybe switch to iterator?
   void visit(StringVisitor visitor);

--- a/src/main/java/build/buildfarm/common/redis/RedisClient.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisClient.java
@@ -33,7 +33,7 @@ public class RedisClient implements Closeable {
 
   @FunctionalInterface
   public interface JedisContext<T> {
-    T run(UnifiedJedis jedis) throws JedisException;
+    T run(UnifiedJedis jedis) throws IOException, JedisException;
   }
 
   @FunctionalInterface

--- a/src/main/java/build/buildfarm/common/redis/RedisHashMap.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisHashMap.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import redis.clients.jedis.AbstractPipeline;
+import redis.clients.jedis.Response;
 import redis.clients.jedis.UnifiedJedis;
 import redis.clients.jedis.params.ScanParams;
 import redis.clients.jedis.resps.ScanResult;
@@ -119,6 +120,10 @@ public class RedisHashMap {
    */
   public long size(UnifiedJedis jedis) {
     return jedis.hlen(name);
+  }
+
+  public Response<Long> size(AbstractPipeline pipeline) {
+    return pipeline.hlen(name);
   }
 
   /**

--- a/src/main/java/build/buildfarm/common/redis/RedisPriorityQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisPriorityQueue.java
@@ -20,7 +20,9 @@ import com.google.common.collect.ImmutableList;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.List;
+import java.util.function.Supplier;
 import lombok.Getter;
+import redis.clients.jedis.AbstractPipeline;
 import redis.clients.jedis.Jedis;
 
 /**
@@ -210,6 +212,10 @@ public class RedisPriorityQueue implements Queue<String> {
    */
   public long size() {
     return jedis.zcard(name);
+  }
+
+  public Supplier<Long> size(AbstractPipeline pipeline) {
+    return pipeline.zcard(name);
   }
 
   /**

--- a/src/main/java/build/buildfarm/common/redis/RedisQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisQueue.java
@@ -21,6 +21,8 @@ import build.buildfarm.common.Queue;
 import build.buildfarm.common.StringVisitor;
 import java.time.Duration;
 import java.util.List;
+import java.util.function.Supplier;
+import redis.clients.jedis.AbstractPipeline;
 import redis.clients.jedis.Jedis;
 
 /**
@@ -160,6 +162,10 @@ public class RedisQueue implements Queue<String> {
    */
   public long size() {
     return jedis.llen(name);
+  }
+
+  public Supplier<Long> size(AbstractPipeline pipeline) {
+    return pipeline.llen(name);
   }
 
   /**

--- a/src/test/java/build/buildfarm/worker/cgroup/GroupTest.java
+++ b/src/test/java/build/buildfarm/worker/cgroup/GroupTest.java
@@ -28,7 +28,6 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class GroupTest {
-
   @Test
   public void testHierarchy() {
     Group g = Group.getRoot().getChild("c1");


### PR DESCRIPTION
Funnel requests made to handle BackplaneStatus through a clustered
pipeline to ensure that it scales with neither the size of the redis
cluster nor the number of queues configured.
BackplaneStatus for a 1ms redis cluster of 8 nodes with 5 queues before:
160ms. After: 10ms. Adding queues or redis cluster nodes is
inconsequential after.