### PR TITLE
fix(docker): set correct JVM args for java-util-logging

### DIFF
--- a/jvm_flags.bzl
+++ b/jvm_flags.bzl
@@ -46,7 +46,7 @@ RECOMMENDED_JVM_FLAGS = [
     "-XX:+HeapDumpOnOutOfMemoryError",
 ]
 
-DEFAULT_LOGGING_CONFIG = ["-Dlogging.config=file:/app/build_buildfarm/src/main/java/build/buildfarm/logging.properties"]
+DEFAULT_LOGGING_CONFIG = ["-Djava.util.logging.config.file=/app/build_buildfarm/src/main/java/build/buildfarm/logging.properties"]
 
 def ensure_accurate_metadata():
     return select({


### PR DESCRIPTION
Fix the JVM argument for the java-util-logging parameter