### PR TITLE
feat: support cgroups v2 and v1

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -17,6 +17,8 @@ cc_binary(
 )
 
 exports_files([
+    # keep sorted
+    "cgexec-wrapper",
     "delay.sh",
     "macos-wrapper.sh",
 ])

--- a/cgexec-wrapper
+++ b/cgexec-wrapper
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -e
+# This is a drop-in replacement for cgexec, with the following differences:
+#
+# - It will put child processes in a cgroup relative to THIS cgroup's parent.
+
+# Required arguments:
+# -g <controllers>:<CgroupName>
+
+# Function to display usage information
+usage() {
+    echo "Usage: $0 -g <value>" >&2
+    exit 1
+}
+
+# Parse command line arguments
+while getopts ":g:" opt; do
+  case ${opt} in
+    g )
+      # Split the value on ":" and assign to variables
+      IFS=':' read -r -a parts <<< "$OPTARG"
+      controllers="${parts[0]}"
+      cgroupName="${parts[1]}"
+      ;;
+    \? )
+      usage
+      ;;
+  esac
+done
+shift $((OPTIND -1))
+
+# Check if both variables are set, otherwise show an error message and exit
+if [ -z "$controllers" ] || [ -z "$cgroupName" ]; then
+    echo "Error: Both controllers and cgroupName must be specified." >&2
+    usage
+fi
+
+# Get my own Cgroup from /proc/self/cgroup.
+# There are three fields here, separated by ':':
+# - the group ID. This is always 0 for cgroups v2.
+# - the enabled controllers. This is always empty for cgroups v2.
+# - the cgroup Path. This is the only part we care about.
+cgroupNameRelativePath="$(cut -d':' -f3- < /proc/self/cgroup)"
+
+# This diverges from `cgexec` where we place ourselves in a group relative to parent.
+# Example:
+# cgroupName = `executions/operations/29aec796-ad19-4e6b-a83b-b8b9f55d0abb`
+# This process starts in the ${cgroupNameRelativePath} cgroup:
+#   ├─${baseCgroup}
+#   │ ├─${cgroupNameRelativePath}
+#   │ │ ├─123456 /tini -- java -jar /app/build_buildfarm/buildfarm-shard-worker_deploy.jar
+#   │ │ └─123457 java -jar /app/build_buildfarm/buildfarm-shard-worker_deploy.jar
+#   │ └─executions
+#   │   └─operations
+#   │     └─29aec796-ad19-4e6b-a83b-b8b9f55d0abb
+#   │        └─123458 ${@}
+baseCgroup=$(dirname "${cgroupNameRelativePath}")
+# Bouncing my own PID $$ into /sys/fs/cgroup${baseCgroup}/$cgroupName"
+echo $$ > "/sys/fs/cgroup${baseCgroup}/$cgroupName/cgroup.procs"
+
+# Exec the rest of the arguments as-is
+exec "$@"

--- a/container/BUILD
+++ b/container/BUILD
@@ -104,6 +104,7 @@ pkg_files(
     }) + [
         # keep sorted
         "//:as-nobody",
+        "//:cgexec-wrapper",
         "//:macos-wrapper.sh",
         "@bazel//src/main/tools:linux-sandbox",
         "@bazel//src/main/tools:process-wrapper",

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -168,7 +168,8 @@ worker:
   persistentWorkerActionMnemonicAllowlist:
   - '*'
 executionWrappers:
-  cgroups: /usr/bin/cgexec
+  cgroups1: /usr/bin/cgexec
+  cgroups2: /app/build_buildfarm/cgexec-wrapper
   unshare: /usr/bin/unshare
   linuxSandbox: /app/build_buildfarm/linux-sandbox
   asNobody: /app/build_buildfarm/as-nobody

--- a/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
+++ b/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
@@ -306,7 +306,17 @@ public final class BuildfarmConfigs {
     // Create a mapping from the execution wrappers to the features they enable.
     ExecutionWrapperProperties wrapperProperties = new ExecutionWrapperProperties();
     wrapperProperties.mapping.put(
-        new ArrayList<String>(Arrays.asList(configs.getExecutionWrappers().getCgroups())),
+        new ArrayList<String>(Arrays.asList(configs.getExecutionWrappers().getCgroups1())),
+        new ArrayList<String>(
+            Arrays.asList(
+                "limit_execution",
+                ExecutionProperties.CORES,
+                ExecutionProperties.MIN_CORES,
+                ExecutionProperties.MAX_CORES,
+                ExecutionProperties.MIN_MEM,
+                ExecutionProperties.MAX_MEM)));
+    wrapperProperties.mapping.put(
+        new ArrayList<String>(Arrays.asList(configs.getExecutionWrappers().getCgroups2())),
         new ArrayList<String>(
             Arrays.asList(
                 "limit_execution",

--- a/src/main/java/build/buildfarm/common/config/ExecutionWrappers.java
+++ b/src/main/java/build/buildfarm/common/config/ExecutionWrappers.java
@@ -26,11 +26,19 @@ import lombok.Data;
 @Data
 public class ExecutionWrappers {
   /**
-   * @field cgroups
-   * @brief The program to use when running actions under cgroups.
+   * @field cgroups2
+   * @brief The program to use when running actions under cgroups v2.
    * @details This program is expected to be packaged with the worker image.
    */
-  private String cgroups = "/app/build_buildfarm/cgexec-wrapper";
+  private String cgroups2 = "/app/build_buildfarm/cgexec-wrapper";
+
+  /**
+   * @field cgroups1
+   * @brief The program to use when running actions under cgroups v1.
+   * @details This program is expected to be packaged with the worker image.
+   */
+  @Deprecated(forRemoval = true)
+  private String cgroups1 = "/usr/bin/cgexec";
 
   /**
    * @field unshare

--- a/src/main/java/build/buildfarm/common/config/ExecutionWrappers.java
+++ b/src/main/java/build/buildfarm/common/config/ExecutionWrappers.java
@@ -30,7 +30,7 @@ public class ExecutionWrappers {
    * @brief The program to use when running actions under cgroups.
    * @details This program is expected to be packaged with the worker image.
    */
-  private String cgroups = "/usr/bin/cgexec";
+  private String cgroups = "/app/build_buildfarm/cgexec-wrapper";
 
   /**
    * @field unshare

--- a/src/main/java/build/buildfarm/worker/ExecuteActionStage.java
+++ b/src/main/java/build/buildfarm/worker/ExecuteActionStage.java
@@ -127,7 +127,7 @@ public class ExecuteActionStage extends SuperscalarPipelineStage {
 
   @Override
   public void run() {
-    workerContext.createExecutionLimits();
+    workerContext.createExecutionLimits(); // TODO: if this throws, we should shutdown the worker.
     super.run();
   }
 }

--- a/src/main/java/build/buildfarm/worker/cgroup/CGroupVersion.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/CGroupVersion.java
@@ -1,3 +1,17 @@
+// Copyright 2025 The Buildfarm Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package build.buildfarm.worker.cgroup;
 
 public enum CGroupVersion {

--- a/src/main/java/build/buildfarm/worker/cgroup/CGroupVersion.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/CGroupVersion.java
@@ -1,0 +1,7 @@
+package build.buildfarm.worker.cgroup;
+
+public enum CGroupVersion {
+  NONE, /* CGroups not detected at all */
+  CGROUPS_V1,
+  CGROUPS_V2,
+}

--- a/src/main/java/build/buildfarm/worker/cgroup/CGroupVersionProvider.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/CGroupVersionProvider.java
@@ -1,3 +1,17 @@
+// Copyright 2025 The Buildfarm Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package build.buildfarm.worker.cgroup;
 
 import java.io.IOException;

--- a/src/main/java/build/buildfarm/worker/cgroup/CGroupVersionProvider.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/CGroupVersionProvider.java
@@ -1,0 +1,44 @@
+package build.buildfarm.worker.cgroup;
+
+import java.io.IOException;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import lombok.extern.java.Log;
+
+@Log
+public class CGroupVersionProvider implements Supplier<CGroupVersion> {
+
+  @Override
+  public CGroupVersion get() {
+    /* Try to figure out which version of CGroups is available. */
+    try {
+      Path path = Path.of("/sys/fs/cgroup");
+      if (path.toFile().exists() && path.toFile().isDirectory()) {
+        FileStore fileStore = Files.getFileStore(path);
+        String fsType = fileStore.type();
+        if (fsType.equals("cgroup2")) {
+          return CGroupVersion.CGROUPS_V2;
+        } else {
+          /* fsType=cgroup or fsType=tmpfs */
+          log.log(
+              Level.WARNING,
+              "cgroups v1 detected at /sys/fs/cgroup ! This is the last Buildfarm version to"
+                  + " support v1 - Please upgrade your host to cgroups v2! See also"
+                  + " https://github.com/buildfarm/buildfarm/issues/2205");
+          return CGroupVersion.CGROUPS_V1;
+        }
+      }
+    } catch (IOException e) {
+      log.log(
+          Level.WARNING,
+          "Could not auto-detect CGroups version in /sys/fs/cgroup, assuming no CGroups support",
+          e);
+    }
+    // Give up.
+    log.log(Level.WARNING, "No cgroups support");
+    return CGroupVersion.NONE;
+  }
+}

--- a/src/main/java/build/buildfarm/worker/cgroup/Cpu.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/Cpu.java
@@ -44,8 +44,8 @@ public class Cpu extends Controller {
    */
   @Deprecated
   public void setShares(int shares) throws IOException {
+    open();
     if (Group.VERSION == CGroupVersion.CGROUPS_V1) {
-      open();
       writeInt("cpu.shares", shares);
     }
   }

--- a/src/main/java/build/buildfarm/worker/cgroup/Group.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/Group.java
@@ -55,6 +55,7 @@ public final class Group {
 
   private static final String CGROUP_CONTROLLERS = "cgroup.controllers";
   private static final String CGROUP_SUBTREE_CONTROL = "cgroup.subtree_control";
+  private static final String EVACUATION_CGROUP_NAME = "evacuation";
 
   /**
    * These are the controllers we need enabled for our execution cgroup so that Buildfarm can set
@@ -397,7 +398,7 @@ public final class Group {
   void create(@Nonnull String controllerName) throws IOException {
     /* root already has all controllers created */
     if (VERSION == CGroupVersion.CGROUPS_V2 && !root.isEmpty(controllerName)) {
-      Group evacuation = root.getChild("evacuation");
+      Group evacuation = root.getChild(EVACUATION_CGROUP_NAME);
       log.log(
           Level.FINE,
           "beginning evacuation of root cgroup for cgroups v2 from "
@@ -442,7 +443,7 @@ public final class Group {
   public static void onShutdown() {
     if (VERSION == CGroupVersion.CGROUPS_V2) {
       try {
-        Group evacuation = root.getChild("evacuation");
+        Group evacuation = root.getChild(EVACUATION_CGROUP_NAME);
         if (evacuation.isEmpty()) {
           // nothing to move back.
           return;
@@ -462,7 +463,7 @@ public final class Group {
         }
         // The great return home - move evacuated processes back to root cgroup, where they started.
         root.adoptPids(evacuation.getPids());
-        // Try to delete the "evacuation" cgroup, which should be empty.
+        // Try to delete the EVACUATION_CGROUP_NAME cgroup, which should be empty.
         // We could check it by reading `cgroup.stat`
         Files.delete(evacuation.getPath());
       } catch (IOException ioe) {

--- a/src/main/java/build/buildfarm/worker/cgroup/Group.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/Group.java
@@ -65,7 +65,7 @@ public final class Group {
   @SuppressWarnings(
       "PMD.MutableStaticState") // Unit tests set this. When CGroups v1 support is gone, this will
   // go away, too.
-  protected static CGroupVersion VERSION = discoverCgroupVersion();
+  public static CGroupVersion VERSION = discoverCgroupVersion();
 
   private static CGroupVersion discoverCgroupVersion() {
     /* Try to figure out which version of CGroups is available. */

--- a/src/main/java/build/buildfarm/worker/cgroup/Group.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/Group.java
@@ -39,6 +39,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import jnr.constants.platform.Signal;
@@ -516,7 +517,7 @@ public final class Group {
         String.format("homecoming - returning child processes to cgroup %s", cgroupPath));
 
     // Depth-first walk through all child cgroups first
-    try (var childDirectories = Files.list(cgroupPath)) {
+    try (Stream<Path> childDirectories = Files.list(cgroupPath)) {
       childDirectories
           .filter(Files::isDirectory)
           .forEach(

--- a/src/main/java/build/buildfarm/worker/cgroup/Group.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/Group.java
@@ -93,6 +93,7 @@ public final class Group {
           e);
     }
     // Give up.
+    log.log(Level.WARNING, "No cgroups support");
     return CGroupVersion.NONE;
   }
 

--- a/src/main/java/build/buildfarm/worker/cgroup/Group.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/Group.java
@@ -24,7 +24,6 @@ import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
 import io.grpc.Deadline;
-import java.io.File;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
@@ -127,7 +126,7 @@ public final class Group {
       return getName();
     }
     /* is child of non-root parent */
-    return parent.getHierarchy() + File.separator + getName();
+    return parent.getHierarchy() + "/" + getName();
   }
 
   /**

--- a/src/main/java/build/buildfarm/worker/cgroup/Mem.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/Mem.java
@@ -22,7 +22,7 @@ public class Mem extends Controller {
   }
 
   @Override
-  public String getName() {
+  public String getControllerName() {
     return "memory";
   }
 

--- a/src/main/java/build/buildfarm/worker/resources/CpuLimits.java
+++ b/src/main/java/build/buildfarm/worker/resources/CpuLimits.java
@@ -15,6 +15,7 @@
 package build.buildfarm.worker.resources;
 
 import java.util.ArrayList;
+import lombok.ToString;
 
 /**
  * @class CpuLimits
@@ -29,6 +30,7 @@ import java.util.ArrayList;
  *     restrictions will ultimately encourage action writers to implement their actions more
  *     efficiently or opt for local execution as an alternative.
  */
+@ToString
 public class CpuLimits {
   /**
    * @field limit

--- a/src/main/java/build/buildfarm/worker/resources/MemLimits.java
+++ b/src/main/java/build/buildfarm/worker/resources/MemLimits.java
@@ -15,6 +15,7 @@
 package build.buildfarm.worker.resources;
 
 import java.util.ArrayList;
+import lombok.ToString;
 
 /**
  * @class MemLimits
@@ -29,6 +30,7 @@ import java.util.ArrayList;
  *     ultimately encourage action writers to implement their actions more efficiently or opt for
  *     local execution as an alternative.
  */
+@ToString
 public class MemLimits {
   /**
    * @field limit

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -827,8 +827,8 @@ class ShardWorkerContext implements WorkerContext {
         /* only divide up our cfs quota if we need to limit below the available processors for executions */
         executionsGroup.getCpu().setMaxCpu(executeStageWidth);
       }
-      // create 1024 * execution width shares to choose from
-      operationsGroup.getCpu().setShares(executeStageWidth * 1024);
+      // create `execution width` shares to choose from. This is the ceiling for the operations
+      operationsGroup.getCpu().setShares(executeStageWidth);
     } catch (IOException e) {
       log.log(Level.WARNING, "Unable to set up CGroup", e);
       try {
@@ -1086,7 +1086,7 @@ class ShardWorkerContext implements WorkerContext {
         cpu.setMaxCpu(limits.cpu.max);
       }
       if (limits.cpu.min > 0) {
-        cpu.setShares(limits.cpu.min * 1024);
+        cpu.setShares(limits.cpu.min);
       }
     } catch (IOException e) {
       // clear interrupt flag if set due to ClosedByInterruptException

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -829,7 +829,7 @@ class ShardWorkerContext implements WorkerContext {
       }
       // create `execution width` shares to choose from. This is the ceiling for the operations
       operationsGroup.getCpu().setShares(executeStageWidth);
-    } catch (IOException e) {
+    } catch (IOException | IllegalStateException e) {
       log.log(Level.WARNING, "Unable to set up CGroup", e);
       try {
         operationsGroup.getCpu().close();

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -60,6 +60,7 @@ import build.buildfarm.worker.ExecutionPolicies;
 import build.buildfarm.worker.MatchListener;
 import build.buildfarm.worker.RetryingMatchListener;
 import build.buildfarm.worker.WorkerContext;
+import build.buildfarm.worker.cgroup.CGroupVersion;
 import build.buildfarm.worker.cgroup.Cpu;
 import build.buildfarm.worker.cgroup.Group;
 import build.buildfarm.worker.cgroup.Mem;
@@ -939,6 +940,13 @@ class ShardWorkerContext implements WorkerContext {
     return resource;
   }
 
+  private String getCgroups() {
+    if (Group.VERSION == CGroupVersion.CGROUPS_V2) {
+      return configs.getExecutionWrappers().getCgroups2();
+    }
+    return configs.getExecutionWrappers().getCgroups1();
+  }
+
   IOResource limitSpecifiedExecution(
       ResourceLimits limits,
       String operationName,
@@ -971,9 +979,7 @@ class ShardWorkerContext implements WorkerContext {
       // Decide the CLI for running under cgroups
       if (!usedGroups.isEmpty()) {
         arguments.add(
-            configs.getExecutionWrappers().getCgroups(),
-            "-g",
-            String.join(",", usedGroups) + ":" + group.getHierarchy());
+            getCgroups(), "-g", String.join(",", usedGroups) + ":" + group.getHierarchy());
       }
     }
 

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -821,18 +821,15 @@ class ShardWorkerContext implements WorkerContext {
     try {
       int availableProcessors = SystemProcessors.get();
       Preconditions.checkState(availableProcessors >= executeStageWidth);
-      int executionsShares =
-          Group.getRoot().getCpu().getShares() * executeStageWidth / availableProcessors;
-      executionsGroup.getCpu().setShares(executionsShares);
+      executionsGroup.getCpu().setMaxCpu(executeStageWidth);
       if (executeStageWidth < availableProcessors) {
         /* only divide up our cfs quota if we need to limit below the available processors for executions */
-        executionsGroup
-            .getCpu()
-            .setCFSQuota(executeStageWidth * Group.getRoot().getCpu().getCFSPeriod());
+        executionsGroup.getCpu().setMaxCpu(executeStageWidth);
       }
       // create 1024 * execution width shares to choose from
       operationsGroup.getCpu().setShares(executeStageWidth * 1024);
     } catch (IOException e) {
+      log.log(Level.WARNING, "Unable to set up CGroup", e);
       try {
         operationsGroup.getCpu().close();
       } catch (IOException closeEx) {
@@ -953,21 +950,22 @@ class ShardWorkerContext implements WorkerContext {
     // and collect group names to use on the CLI.
     String operationId = getOperationId(operationName);
     ArrayList<IOResource> resources = new ArrayList<>();
-
     if (limits.cgroups) {
       final Group group = operationsGroup.getChild(operationId);
       ArrayList<String> usedGroups = new ArrayList<>();
 
       // Possibly set core restrictions.
       if (limits.cpu.limit) {
+        log.log(Level.FINEST, "Applying CPU limit {0}", limits.cpu);
         applyCpuLimits(group, owner, limits, resources);
-        usedGroups.add(group.getCpu().getName());
+        usedGroups.add(group.getCpu().getControllerName());
       }
 
       // Possibly set memory restrictions.
       if (limits.mem.limit) {
+        log.log(Level.FINEST, "Applying Mem limit {0}", limits.mem);
         applyMemLimits(group, owner, limits, resources);
-        usedGroups.add(group.getMem().getName());
+        usedGroups.add(group.getMem().getControllerName());
       }
 
       // Decide the CLI for running under cgroups
@@ -1079,9 +1077,7 @@ class ShardWorkerContext implements WorkerContext {
       }
 
       if (limits.cpu.max > 0) {
-        /* period of 100ms */
-        cpu.setCFSPeriod(100000);
-        cpu.setCFSQuota(limits.cpu.max * 100000);
+        cpu.setMaxCpu(limits.cpu.max);
       }
       if (limits.cpu.min > 0) {
         cpu.setShares(limits.cpu.min * 1024);

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -73,6 +73,7 @@ import build.buildfarm.worker.PipelineStage;
 import build.buildfarm.worker.PutOperationStage;
 import build.buildfarm.worker.ReportResultStage;
 import build.buildfarm.worker.SuperscalarPipelineStage;
+import build.buildfarm.worker.cgroup.Group;
 import build.buildfarm.worker.resources.LocalResourceSet;
 import build.buildfarm.worker.resources.LocalResourceSet.PoolResource;
 import build.buildfarm.worker.resources.LocalResourceSetUtils;
@@ -844,6 +845,8 @@ public final class Worker extends LoggingMain {
   private void shutdown() throws InterruptedException {
     log.info("*** shutting down gRPC server since JVM is shutting down");
     prepareWorkerForGracefulShutdown();
+    // Clean-up any cgroups that were possibly created/mutated.
+    Group.onShutdown();
     PrometheusPublisher.stopHttpServer();
     boolean interrupted = Thread.interrupted();
     if (pipeline != null) {

--- a/src/test/java/build/buildfarm/worker/cgroup/BUILD
+++ b/src/test/java/build/buildfarm/worker/cgroup/BUILD
@@ -6,6 +6,7 @@ java_test(
     srcs = glob(["*.java"]),
     test_class = "build.buildfarm.AllTests",
     deps = [
+        "//src/main/java/build/buildfarm/common/base",
         "//src/main/java/build/buildfarm/worker/cgroup",
         "//src/test/java/build/buildfarm:test_runner",
         "@maven//:com_google_guava_guava",

--- a/src/test/java/build/buildfarm/worker/cgroup/CGroupVersionProviderTest.java
+++ b/src/test/java/build/buildfarm/worker/cgroup/CGroupVersionProviderTest.java
@@ -1,0 +1,163 @@
+package build.buildfarm.worker.cgroup;
+
+import static build.buildfarm.common.base.System.isWindows;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+@RunWith(JUnit4.class)
+public class CGroupVersionProviderTest {
+
+  @Before
+  public void setup() throws IOException {
+    Assume.assumeFalse(isWindows());
+  }
+
+  private void testDetectCGroups(String type, CGroupVersion detectedVersion) throws IOException {
+    // Create a mock FileStore that returns `type` as the type
+    FileStore mockFileStore = mock(FileStore.class);
+    when(mockFileStore.type()).thenReturn(type);
+
+    try (MockedStatic<Files> mockedFiles = Mockito.mockStatic(Files.class);
+        MockedStatic<Path> mockedPath = Mockito.mockStatic(Path.class)) {
+
+      // Mock Path.of to return a path we can control
+      Path mockPath = mock(Path.class);
+      mockedPath.when(() -> Path.of("/sys/fs/cgroup")).thenReturn(mockPath);
+      // Make the toFile().exists() return false
+      java.io.File mockFile = mock(java.io.File.class);
+      when(mockPath.toFile()).thenReturn(mockFile);
+      when(mockFile.exists()).thenReturn(true);
+      when(mockFile.isDirectory()).thenReturn(true);
+
+      // Mock the Files.getFileStore method to return our mock FileStore
+      mockedFiles.when(() -> Files.getFileStore(mockPath)).thenReturn(mockFileStore);
+
+      // Create the provider and call the get method
+      CGroupVersionProvider provider = new CGroupVersionProvider();
+      CGroupVersion result = provider.get();
+
+      // Verify that it correctly detected CGroups
+      assertEquals(detectedVersion, result);
+
+      // Verify interactions with our mocks
+      mockedFiles.verify(() -> Files.getFileStore(mockPath));
+      verify(mockFileStore, times(1)).type();
+      mockedPath.verify(() -> Path.of("/sys/fs/cgroup"));
+      verify(mockPath, times(2)).toFile();
+      verify(mockFile).exists();
+      verify(mockFile).isDirectory();
+
+      verifyNoMoreInteractions(mockPath, mockFile, mockFileStore);
+      mockedFiles.verifyNoMoreInteractions();
+      mockedPath.verifyNoMoreInteractions();
+    }
+  }
+
+  @Test
+  public void testDetectCGroupsV1() throws IOException {
+    testDetectCGroups("cgroup", CGroupVersion.CGROUPS_V1);
+  }
+
+  @Test
+  public void testDetectCGroupsV1tmpfs() throws IOException {
+    /* Sometimes it is mounted as tmpfs inside k8s */
+    testDetectCGroups("tmpfs", CGroupVersion.CGROUPS_V1);
+  }
+
+  @Test
+  public void testDetectCGroupsV2() throws IOException {
+    testDetectCGroups("cgroup2", CGroupVersion.CGROUPS_V2);
+  }
+
+  @Test
+  public void testNoCGroupsWhenDirectoryDoesntExist() {
+    try (MockedStatic<Files> mockedFiles = Mockito.mockStatic(Files.class);
+        MockedStatic<Path> mockedPath = Mockito.mockStatic(Path.class)) {
+
+      // Mock Path.of to return a path we can control
+      Path mockPath = mock(Path.class);
+      mockedPath.when(() -> Path.of("/sys/fs/cgroup")).thenReturn(mockPath);
+
+      // Make the toFile().exists() return false
+      java.io.File mockFile = mock(java.io.File.class);
+      when(mockPath.toFile()).thenReturn(mockFile);
+      when(mockFile.exists()).thenReturn(false);
+
+      // Create the provider and call the get method
+      CGroupVersionProvider provider = new CGroupVersionProvider();
+      CGroupVersion result = provider.get();
+
+      // Verify that it correctly detected no CGroups
+      assertEquals(CGroupVersion.NONE, result);
+
+      // Verify interactions with our mocks
+      mockedPath.verify(() -> Path.of("/sys/fs/cgroup"));
+      verify(mockPath).toFile();
+      verify(mockFile).exists();
+      // We should never check isDirectory if exists() returns false
+      verify(mockFile, Mockito.never()).isDirectory();
+      // We should never call Files.getFileStore if the directory doesn't exist
+      mockedFiles.verifyNoInteractions();
+
+      mockedPath.verifyNoMoreInteractions();
+    }
+
+    // No need to verify mockFile and mockPath outside of the try block
+    // as they are only referenced within the scope of the MockedStatic resources
+  }
+
+  @Test
+  public void testIOExceptionHandling() {
+    try (MockedStatic<Files> mockedFiles = Mockito.mockStatic(Files.class);
+        MockedStatic<Path> mockedPath = Mockito.mockStatic(Path.class)) {
+
+      // Mock Path.of to return a path we can control
+      Path mockPath = mock(Path.class);
+      mockedPath.when(() -> Path.of("/sys/fs/cgroup")).thenReturn(mockPath);
+
+      // Make the toFile().exists() return true
+      java.io.File mockFile = mock(java.io.File.class);
+      when(mockPath.toFile()).thenReturn(mockFile);
+      when(mockFile.exists()).thenReturn(true);
+      when(mockFile.isDirectory()).thenReturn(true);
+
+      // Make Files.getFileStore throw an IOException
+      mockedFiles
+          .when(() -> Files.getFileStore(mockPath))
+          .thenThrow(new IOException("Test IOException"));
+
+      // Create the provider and call the get method
+      CGroupVersionProvider provider = new CGroupVersionProvider();
+      CGroupVersion result = provider.get();
+
+      // Verify that it correctly falls back to NONE when there's an exception
+      assertEquals(CGroupVersion.NONE, result);
+
+      // Verify interactions with our mocks
+      mockedPath.verify(() -> Path.of("/sys/fs/cgroup"));
+      verify(mockPath, times(2)).toFile();
+      verify(mockFile).exists();
+      verify(mockFile).isDirectory();
+      mockedFiles.verify(() -> Files.getFileStore(mockPath));
+
+      mockedPath.verifyNoMoreInteractions();
+      mockedFiles.verifyNoMoreInteractions();
+    }
+  }
+}

--- a/src/test/java/build/buildfarm/worker/cgroup/CGroupVersionProviderTest.java
+++ b/src/test/java/build/buildfarm/worker/cgroup/CGroupVersionProviderTest.java
@@ -1,3 +1,17 @@
+// Copyright 2025 The Buildfarm Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package build.buildfarm.worker.cgroup;
 
 import static build.buildfarm.common.base.System.isWindows;

--- a/src/test/java/build/buildfarm/worker/cgroup/GroupTest.java
+++ b/src/test/java/build/buildfarm/worker/cgroup/GroupTest.java
@@ -1,0 +1,144 @@
+// Copyright 2024 The Buildfarm Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker.cgroup;
+
+import static build.buildfarm.common.base.System.isWindows;
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link Group#getSelfCgroup} method. */
+@RunWith(JUnit4.class)
+public class GroupTest {
+
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private Path procSelfCgroupPath;
+
+  @Before
+  public void setup() throws IOException {
+    Assume.assumeFalse(isWindows());
+
+    // Create a temporary file to simulate /proc/self/cgroup
+    procSelfCgroupPath = temporaryFolder.newFile("cgroup").toPath();
+  }
+
+  /**
+   * Test helper that creates a custom implementation of getSelfCgroup for testing by using a local
+   * implementation with the same logic but accessing our test file instead of the real
+   * /proc/self/cgroup file.
+   */
+  private Path testGetSelfCgroup(CGroupVersion version, List<String> fileContent)
+      throws IOException {
+    // Write our test data to the temporary file
+    if (fileContent != null) {
+      Files.write(procSelfCgroupPath, fileContent);
+    }
+
+    // This is a test-only implementation with the same logic as Group.getSelfCgroup
+    // but using our test file instead of the real /proc/self/cgroup
+    if (version == CGroupVersion.CGROUPS_V2) {
+      try {
+        List<String> myCgroups = Files.readAllLines(procSelfCgroupPath);
+
+        for (String line : myCgroups) {
+          if (line.startsWith("0::")) {
+            return Path.of("/sys/fs/cgroup", line.substring(3).trim());
+          }
+        }
+      } catch (IOException ioe) {
+        // Fall through to default
+      }
+    }
+    return Paths.get("/sys/fs/cgroup");
+  }
+
+  @Test
+  public void testGetSelfCgroupV2() throws IOException {
+    // Arrange: Setup cgroups v2 content
+    List<String> cgroupV2Content = List.of("0::/user.slice/user-1000.slice/session-2.scope");
+
+    // Act: Call our test implementation
+    Path result = testGetSelfCgroup(CGroupVersion.CGROUPS_V2, cgroupV2Content);
+
+    // Assert: Verify result path is correctly constructed
+    assertThat(result.toString())
+        .isEqualTo("/sys/fs/cgroup/user.slice/user-1000.slice/session-2.scope");
+  }
+
+  @Test
+  public void testGetSelfCgroupV1() throws IOException {
+    // Act: Call the test implementation with cgroups v1
+    Path result = testGetSelfCgroup(CGroupVersion.CGROUPS_V1, null);
+
+    // Assert: For v1, it should always return /sys/fs/cgroup regardless of file content
+    assertThat(result.toString()).isEqualTo("/sys/fs/cgroup");
+  }
+
+  @Test
+  public void testGetSelfCgroupV2WithMultipleLines() throws IOException {
+    // Arrange: Setup cgroups v2 content with multiple lines (realistic content)
+    List<String> cgroupV2Content =
+        List.of(
+            "0::/user.slice/user-1000.slice/session-2.scope",
+            "1:name=systemd:/user.slice/user-1000.slice/session-2.scope");
+
+    // Act: Call our test implementation
+    Path result = testGetSelfCgroup(CGroupVersion.CGROUPS_V2, cgroupV2Content);
+
+    // Assert: Verify result path is correctly constructed, using first line starting with 0::
+    assertThat(result.toString())
+        .isEqualTo("/sys/fs/cgroup/user.slice/user-1000.slice/session-2.scope");
+  }
+
+  @Test
+  public void testGetSelfCgroupV2WithIOException() throws IOException {
+    // For this test, we don't write any content to the file
+    // and make the file inaccessible
+    Files.delete(procSelfCgroupPath);
+
+    // Act: Call our test implementation
+    Path result = testGetSelfCgroup(CGroupVersion.CGROUPS_V2, null);
+
+    // Assert: Fallback to default path when exception occurs
+    assertThat(result.toString()).isEqualTo("/sys/fs/cgroup");
+  }
+
+  @Test
+  public void testGetSelfCgroupV2WithNoMatchingLine() throws IOException {
+    // Arrange: Setup content with no line starting with "0::"
+    List<String> cgroupContent =
+        List.of(
+            "1:name=systemd:/user.slice/user-1000.slice/session-2.scope",
+            "2:cpu,cpuacct:/user.slice");
+
+    // Act: Call our test implementation
+    Path result = testGetSelfCgroup(CGroupVersion.CGROUPS_V2, cgroupContent);
+
+    // Assert: Falls back to default path when no matching line is found
+    assertThat(result.toString()).isEqualTo("/sys/fs/cgroup");
+  }
+}

--- a/src/test/java/build/buildfarm/worker/cgroup/GroupV1Test.java
+++ b/src/test/java/build/buildfarm/worker/cgroup/GroupV1Test.java
@@ -1,4 +1,4 @@
-// Copyright 2024 The Buildfarm Authors. All rights reserved.
+// Copyright 2024 The Bazel Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,52 +14,61 @@
 
 package build.buildfarm.worker.cgroup;
 
+import static build.buildfarm.common.base.System.isWindows;
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Set;
+import org.junit.Assume;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+/** These test CGroups v1 behavior. When CGroups v1 is no longer supported, delete these tests. */
 @RunWith(JUnit4.class)
-public class GroupTest {
+public class GroupV1Test {
+
+  @Before
+  public void setup() {
+    Group.VERSION = CGroupVersion.CGROUPS_V1;
+    Assume.assumeFalse(isWindows());
+  }
+
   @Test
   public void testHierarchy() {
     Group g = Group.getRoot().getChild("c1");
     assertThat(g).isNotNull();
-    assertThat(g.getHierarchy()).isEqualTo("c1");
-    assertThat(g.getChild("c2").getHierarchy()).isEqualTo("c1/c2");
     assertThat(g.getHierarchy("cpu")).isEqualTo("cpu/c1");
   }
 
   @Test
   public void testGetPathWithControllerName() {
     Group g = Group.getRoot().getChild("c1");
-    assertThat(g.getPath("banana")).isEqualTo(Path.of("/sys/fs/cgroup/banana/c1"));
+
+    // If we're not in cgroups, it looks like this
+    // But we don't assert this, as running this test on remote-exec with cgroups gets a path
+    // more like this: //sys/fs/cgroup/KUBERENTES-SLICE/POD-ETC/c1
+    // assertThat(g.getPath()).isEqualTo(Path.of("/sys/fs/cgroup/banana/c1"));
+    Path gPath = g.getPath("banana");
+    assertThat(gPath.toString()).startsWith("/sys/fs/cgroup/");
+    assertThat(gPath.toString()).endsWith("/banana/c1");
 
     Group g2 = g.getChild("c2");
-    assertThat(g2.getPath("apple")).isEqualTo(Path.of("/sys/fs/cgroup/apple/c1/c2"));
-  }
-
-  @Test
-  public void testGetPath() {
-    Group g = Group.getRoot().getChild("c1");
-    assertThat(g.getPath()).isEqualTo(Path.of("/sys/fs/cgroup/c1"));
-
-    Group g2 = g.getChild("c2");
-    assertThat(g2.getPath()).isEqualTo(Path.of("/sys/fs/cgroup/c1/c2"));
+    Path g2Path = g2.getPath("apple");
+    assertThat(g2Path.toString()).startsWith("/sys/fs/cgroup/");
+    assertThat(g2Path.toString()).endsWith("/apple/c1/c2");
   }
 
   @Test
   public void testIsEmpty() throws IOException {
     Group mockGroup = spy(Group.getRoot().getChild("c1"));
-    when(mockGroup.getPids(anyString())).thenReturn(Set.of(7, 8, 9));
+    String myController = "cpu";
+    when(mockGroup.getPids(myController)).thenReturn(Set.of(7, 8, 9));
 
-    assertThat(mockGroup.isEmpty("cpu")).isFalse();
+    assertThat(mockGroup.isEmpty(myController)).isFalse();
   }
 }

--- a/src/test/java/build/buildfarm/worker/cgroup/GroupV2Test.java
+++ b/src/test/java/build/buildfarm/worker/cgroup/GroupV2Test.java
@@ -1,0 +1,74 @@
+// Copyright 2024 The Buildfarm Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker.cgroup;
+
+import static build.buildfarm.common.base.System.isWindows;
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Set;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** These test CGroups v2 behavior exclusively. */
+@RunWith(JUnit4.class)
+public class GroupV2Test {
+
+  @Before
+  public void setup() {
+    Group.VERSION = CGroupVersion.CGROUPS_V2;
+    Assume.assumeFalse(isWindows());
+  }
+
+  @Test
+  public void testHierarchy() {
+    Group g = Group.getRoot().getChild("c1");
+    assertThat(g).isNotNull();
+    assertThat(g.getHierarchy()).isEqualTo("c1");
+    assertThat(g.getChild("c2").getHierarchy()).isEqualTo("c1/c2");
+  }
+
+  @Test
+  public void testGetPath() {
+    Group g = Group.getRoot().getChild("c1");
+    Path gPath = g.getPath();
+    assertThat(gPath.toString()).startsWith("/sys/fs/cgroup/");
+    assertThat(gPath.toString()).endsWith("/c1");
+
+    // If we're not in cgroups, it looks like this
+    // But we don't assert this, as running this test on remote-exec with cgroups gets a path
+    // more like this: //sys/fs/cgroup/KUBERENTES-SLICE/POD-ETC/c1
+    // assertThat(g.getPath()).isEqualTo(Path.of("/sys/fs/cgroup/c1"));
+
+    Group g2 = g.getChild("c2");
+    Path g2Path = g2.getPath();
+    assertThat(g2Path.toString()).startsWith("/sys/fs/cgroup/");
+    assertThat(g2Path.toString()).endsWith("/c1/c2");
+  }
+
+  @Test
+  public void testIsEmpty() throws IOException {
+    Group mockGroup = spy(Group.getRoot().getChild("c1"));
+    when(mockGroup.getPids()).thenReturn(Set.of(7, 8, 9));
+
+    assertThat(mockGroup.isEmpty()).isFalse();
+  }
+}


### PR DESCRIPTION
This adds support for cgroups v2 and maintains support for cgroups v1 for one more release. (v2.16.0)

Efforts made to keep v1 and v2 separate so that v1 support can be removed without a ton more refactoring.

cgroups v1 removal is tracked here: https://github.com/buildfarm/buildfarm/issues/2205

## Recommended upgrade path for existing cgroups v1 users:
- Upgrade buildfarm to v2.15.0. Note the warning in the exec-worker startup logs:
```
cgroups v1 detected at /sys/fs/cgroup ! This is the last Buildfarm version to
support v1 - Please upgrade your host to cgroups v2! See also 
https://github.com/buildfarm/buildfarm/issues/2205
```
- Ensure things still work in v1 mode
- upgrade kernel boot arguments for the node to enable v2. Reboot
- on the host node, ensure cgroups v2 is active.
```sh
stat -fc %T /sys/fs/cgroup/
```
should say `cgroup2fs`
- Start buildfarm
- Check that the cgroupv1 warning is no longer present in the start-up logs for exec workers.

----
Fixes: https://github.com/buildfarm/buildfarm/issues/1834