### PR TITLE
refactor: prefer getFirst() over get(0)

### DIFF
--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -626,7 +626,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
       return decoder
           .parameters()
           .getOrDefault("THROUGH", ImmutableList.of("false"))
-          .get(0)
+          .getFirst()
           .equals("true");
     } catch (URISyntaxException e) {
       return false;

--- a/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
+++ b/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
@@ -143,7 +143,7 @@ public final class BuildfarmConfigs {
       throw new ConfigurationException("A valid path to a configuration file must be provided.");
     }
 
-    return Paths.get(residue.get(0));
+    return Paths.get(residue.getFirst());
   }
 
   private static void adjustServerConfigs(BuildfarmConfigs configs) {

--- a/src/main/java/build/buildfarm/common/redis/RedisNodeHashes.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisNodeHashes.java
@@ -54,7 +54,7 @@ public class RedisNodeHashes {
         for (List<List<Long>> slotRanges : nodeSlotRanges) {
           // we can use any slot that is in range for the node.
           // in this case, we will use the first slot in the first range.
-          hashTags.add(RedisSlotToHash.correlate(slotRanges.get(0).get(0)));
+          hashTags.add(RedisSlotToHash.correlate(slotRanges.getFirst().getFirst()));
         }
         return hashTags.build();
       } catch (JedisException e) {

--- a/src/main/java/build/buildfarm/instance/server/NodeInstance.java
+++ b/src/main/java/build/buildfarm/instance/server/NodeInstance.java
@@ -356,7 +356,7 @@ public abstract class NodeInstance extends InstanceBase {
       return decoder
           .parameters()
           .getOrDefault("ENSURE_OUTPUTS_PRESENT", ImmutableList.of("false"))
-          .get(0)
+          .getFirst()
           .equals("true");
     } catch (URISyntaxException e) {
       return false;

--- a/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
@@ -3064,7 +3064,7 @@ public class ServerInstance extends NodeInstance {
       // If the query contains a single 'id' parameter it is used
       List<String> ids = parameters.get("id");
       if (ids.size() == 1) {
-        id = ids.get(0);
+        id = ids.getFirst();
       }
     }
 

--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -535,7 +535,7 @@ class Executor {
       String message;
       if (t != null) {
         message =
-            "Cannot run program \"" + processBuilder.command().get(0) + "\": " + t.getMessage();
+            "Cannot run program \"" + processBuilder.command().getFirst() + "\": " + t.getMessage();
       } else {
         message = e.getMessage();
       }

--- a/src/main/java/build/buildfarm/worker/persistent/PersistentExecutor.java
+++ b/src/main/java/build/buildfarm/worker/persistent/PersistentExecutor.java
@@ -123,7 +123,7 @@ public class PersistentExecutor {
 
     WorkerInputs workerFiles = WorkerInputs.from(context, requestArgs);
 
-    Path binary = Paths.get(workerExecCmd.get(0));
+    Path binary = Paths.get(workerExecCmd.getFirst());
     if (!workerFiles.containsTool(binary) && !binary.isAbsolute()) {
       throw new IllegalArgumentException(
           "Binary wasn't a tool input nor an absolute path: " + binary);
@@ -257,7 +257,7 @@ public class PersistentExecutor {
   }
 
   private static String getExecutionName(ImmutableList<String> argsList) {
-    boolean isScalac = argsList.size() > 1 && argsList.get(0).endsWith("scalac/scalac");
+    boolean isScalac = argsList.size() > 1 && argsList.getFirst().endsWith("scalac/scalac");
     if (isScalac) {
       return SCALAC_EXEC_NAME;
     } else if (argsList.contains(JAVABUILDER_JAR)) {

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -666,7 +666,7 @@ public final class Worker extends LoggingMain {
 
     removeWorker(configs.getWorker().getPublicName());
 
-    boolean skipLoad = configs.getWorker().getStorages().get(0).isSkipLoad();
+    boolean skipLoad = configs.getWorker().getStorages().getFirst().isSkipLoad();
     execFileSystem.start(
         (digests) -> addBlobsLocation(digests, configs.getWorker().getPublicName()), skipLoad);
 

--- a/src/test/java/build/buildfarm/instance/server/NodeInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/server/NodeInstanceTest.java
@@ -253,7 +253,7 @@ public class NodeInstanceTest {
         preconditionFailure);
 
     assertThat(preconditionFailure.getViolationsCount()).isEqualTo(1);
-    Violation violation = preconditionFailure.getViolationsList().get(0);
+    Violation violation = preconditionFailure.getViolationsList().getFirst();
     assertThat(violation.getType()).isEqualTo(VIOLATION_TYPE_INVALID);
     assertThat(violation.getSubject()).isEqualTo("/: foo");
     assertThat(violation.getDescription()).isEqualTo(DUPLICATE_DIRENT);
@@ -315,7 +315,7 @@ public class NodeInstanceTest {
         preconditionFailure);
 
     assertThat(preconditionFailure.getViolationsCount()).isEqualTo(1);
-    Violation violation = preconditionFailure.getViolationsList().get(0);
+    Violation violation = preconditionFailure.getViolationsList().getFirst();
     assertThat(violation.getType()).isEqualTo(VIOLATION_TYPE_INVALID);
     assertThat(violation.getSubject()).isEqualTo("/: foo > bar");
     assertThat(violation.getDescription()).isEqualTo(DIRECTORY_NOT_SORTED);
@@ -352,7 +352,7 @@ public class NodeInstanceTest {
         preconditionFailure);
 
     assertThat(preconditionFailure.getViolationsCount()).isEqualTo(1);
-    Violation violation = preconditionFailure.getViolationsList().get(0);
+    Violation violation = preconditionFailure.getViolationsList().getFirst();
     assertThat(violation.getType()).isEqualTo(VIOLATION_TYPE_INVALID);
     assertThat(violation.getSubject()).isEqualTo("/: foo");
     assertThat(violation.getDescription()).isEqualTo(DUPLICATE_DIRENT);
@@ -389,7 +389,7 @@ public class NodeInstanceTest {
         preconditionFailure);
 
     assertThat(preconditionFailure.getViolationsCount()).isEqualTo(1);
-    Violation violation = preconditionFailure.getViolationsList().get(0);
+    Violation violation = preconditionFailure.getViolationsList().getFirst();
     assertThat(violation.getType()).isEqualTo(VIOLATION_TYPE_INVALID);
     assertThat(violation.getSubject()).isEqualTo("/: foo > bar");
     assertThat(violation.getDescription()).isEqualTo(DIRECTORY_NOT_SORTED);
@@ -417,7 +417,7 @@ public class NodeInstanceTest {
         preconditionFailure);
 
     assertThat(preconditionFailure.getViolationsCount()).isEqualTo(1);
-    Violation violation = preconditionFailure.getViolationsList().get(0);
+    Violation violation = preconditionFailure.getViolationsList().getFirst();
     assertThat(violation.getType()).isEqualTo(VIOLATION_TYPE_INVALID);
     assertThat(violation.getSubject()).isEqualTo("/: foo -> /root/secret");
     assertThat(violation.getDescription()).isEqualTo(SYMLINK_TARGET_ABSOLUTE);
@@ -450,7 +450,7 @@ public class NodeInstanceTest {
         preconditionFailureBuilder);
     PreconditionFailure preconditionFailure = preconditionFailureBuilder.build();
     assertThat(preconditionFailure.getViolationsCount()).isEqualTo(1);
-    Violation violation = preconditionFailure.getViolationsList().get(0);
+    Violation violation = preconditionFailure.getViolationsList().getFirst();
     assertThat(violation.getType()).isEqualTo(VIOLATION_TYPE_INVALID);
     assertThat(violation.getSubject()).isEqualTo("foo");
     assertThat(violation.getDescription()).isEqualTo(OUTPUT_DIRECTORY_IS_OUTPUT_ANCESTOR);
@@ -467,7 +467,7 @@ public class NodeInstanceTest {
         preconditionFailureBuilder);
     PreconditionFailure preconditionFailure = preconditionFailureBuilder.build();
     assertThat(preconditionFailure.getViolationsCount()).isEqualTo(1);
-    Violation violation = preconditionFailure.getViolationsList().get(0);
+    Violation violation = preconditionFailure.getViolationsList().getFirst();
     assertThat(violation.getType()).isEqualTo(VIOLATION_TYPE_INVALID);
     assertThat(violation.getSubject()).isEqualTo("foo");
     assertThat(violation.getDescription()).isEqualTo(OUTPUT_DIRECTORY_IS_OUTPUT_ANCESTOR);
@@ -484,7 +484,7 @@ public class NodeInstanceTest {
         preconditionFailureBuilder);
     PreconditionFailure preconditionFailure = preconditionFailureBuilder.build();
     assertThat(preconditionFailure.getViolationsCount()).isEqualTo(1);
-    Violation violation = preconditionFailure.getViolationsList().get(0);
+    Violation violation = preconditionFailure.getViolationsList().getFirst();
     assertThat(violation.getType()).isEqualTo(VIOLATION_TYPE_INVALID);
     assertThat(violation.getSubject()).isEqualTo("foo");
     assertThat(violation.getDescription()).isEqualTo(OUTPUT_FILE_IS_OUTPUT_ANCESTOR);
@@ -504,7 +504,7 @@ public class NodeInstanceTest {
         preconditionFailureBuilder);
     PreconditionFailure preconditionFailure = preconditionFailureBuilder.build();
     assertThat(preconditionFailure.getViolationsCount()).isEqualTo(1);
-    Violation violation = preconditionFailure.getViolationsList().get(0);
+    Violation violation = preconditionFailure.getViolationsList().getFirst();
     assertThat(violation.getType()).isEqualTo(VIOLATION_TYPE_INVALID);
     assertThat(violation.getSubject()).isEqualTo(INVALID_COMMAND);
     assertThat(violation.getDescription()).isEqualTo("argument list is empty");
@@ -524,7 +524,7 @@ public class NodeInstanceTest {
         preconditionFailureBuilder);
     PreconditionFailure preconditionFailure = preconditionFailureBuilder.build();
     assertThat(preconditionFailure.getViolationsCount()).isEqualTo(1);
-    Violation violation = preconditionFailure.getViolationsList().get(0);
+    Violation violation = preconditionFailure.getViolationsList().getFirst();
     assertThat(violation.getType()).isEqualTo(VIOLATION_TYPE_INVALID);
     assertThat(violation.getSubject()).isEqualTo(INVALID_COMMAND);
     assertThat(violation.getDescription()).isEqualTo("working directory is absolute");
@@ -545,7 +545,7 @@ public class NodeInstanceTest {
         preconditionFailureBuilder);
     PreconditionFailure preconditionFailure = preconditionFailureBuilder.build();
     assertThat(preconditionFailure.getViolationsCount()).isEqualTo(1);
-    Violation violation = preconditionFailure.getViolationsList().get(0);
+    Violation violation = preconditionFailure.getViolationsList().getFirst();
     assertThat(violation.getType()).isEqualTo(VIOLATION_TYPE_INVALID);
     assertThat(violation.getSubject()).isEqualTo(INVALID_COMMAND);
     assertThat(violation.getDescription()).isEqualTo("working directory is not an input directory");
@@ -589,7 +589,7 @@ public class NodeInstanceTest {
     String missingSubject = "blobs/" + DigestUtil.toString(missingDirectoryDigest);
     String missingFmt = "The directory `/%s` was not found in the CAS.";
     assertThat(preconditionFailure.getViolationsCount()).isEqualTo(2);
-    Violation violation = preconditionFailure.getViolationsList().get(0);
+    Violation violation = preconditionFailure.getViolationsList().getFirst();
     assertThat(violation.getType()).isEqualTo(VIOLATION_TYPE_MISSING);
     assertThat(violation.getSubject()).isEqualTo(missingSubject);
     assertThat(violation.getDescription()).isEqualTo(String.format(missingFmt, "bar"));
@@ -658,7 +658,7 @@ public class NodeInstanceTest {
     String missingSubject = "blobs/" + DigestUtil.toString(missingDirectoryDigest);
     String missingFmt = "The directory `/%s` was not found in the CAS.";
     assertThat(preconditionFailure.getViolationsCount()).isEqualTo(2);
-    Violation violation = preconditionFailure.getViolationsList().get(0);
+    Violation violation = preconditionFailure.getViolationsList().getFirst();
     assertThat(violation.getType()).isEqualTo(VIOLATION_TYPE_MISSING);
     assertThat(violation.getSubject()).isEqualTo(missingSubject);
     assertThat(violation.getDescription()).isEqualTo(String.format(missingFmt, "bar/quux"));

--- a/src/test/java/build/buildfarm/server/BuildFarmServerIntegrationTest.java
+++ b/src/test/java/build/buildfarm/server/BuildFarmServerIntegrationTest.java
@@ -115,7 +115,7 @@ public class BuildFarmServerIntegrationTest {
     Queue[] queues = new Queue[1];
     queues[0] = queue;
     configs.getBackplane().setQueues(queues);
-    configs.getWorker().getStorages().get(0).setType(MEMORY);
+    configs.getWorker().getStorages().getFirst().setType(MEMORY);
     String uniqueServerName = "in-process server for " + getClass();
     server = new BuildFarmServer();
     server.start(
@@ -139,7 +139,7 @@ public class BuildFarmServerIntegrationTest {
                 .addDigests(DigestUtil.toDigest(digest))
                 .setDigestFunction(digest.getDigestFunction())
                 .build());
-    BatchReadBlobsResponse.Response response = batchResponse.getResponsesList().get(0);
+    BatchReadBlobsResponse.Response response = batchResponse.getResponsesList().getFirst();
     com.google.rpc.Status status = response.getStatus();
     if (Code.forNumber(status.getCode()) == Code.NOT_FOUND) {
       return null;
@@ -333,9 +333,9 @@ public class BuildFarmServerIntegrationTest {
     assertThat(status.getCode()).isEqualTo(Code.FAILED_PRECONDITION.getNumber());
     assertThat(status.getDetailsCount()).isEqualTo(1);
     PreconditionFailure preconditionFailure =
-        status.getDetailsList().get(0).unpack(PreconditionFailure.class);
+        status.getDetailsList().getFirst().unpack(PreconditionFailure.class);
     assertThat(preconditionFailure.getViolationsCount()).isEqualTo(1);
-    Violation violation = preconditionFailure.getViolationsList().get(0);
+    Violation violation = preconditionFailure.getViolationsList().getFirst();
     assertThat(violation.getType()).isEqualTo(VIOLATION_TYPE_INVALID);
   }
 

--- a/src/test/java/build/buildfarm/worker/InputFetchStageTest.java
+++ b/src/test/java/build/buildfarm/worker/InputFetchStageTest.java
@@ -122,7 +122,7 @@ public class InputFetchStageTest {
             any(Runnable.class),
             any(Deadline.class));
     verifyNoMoreInteractions(workerContext);
-    ExecutionContext executionContext = error.getExecutionContexts().get(0);
+    ExecutionContext executionContext = error.getExecutionContexts().getFirst();
     assertThat(executionContext).isEqualTo(badContext);
   }
 }


### PR DESCRIPTION
There are still some `get(0)` when `get(1)` is nearby.