### PR TITLE
add extraVolumes / extraVolumeMounts support to buildfarm server

### DIFF
--- a/kubernetes/helm-charts/buildfarm/templates/server/deployment.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/server/deployment.yaml
@@ -61,6 +61,9 @@ spec:
             - mountPath: /server-log-props
               name: server-log-props
               readOnly: true
+            {{- with .Values.server.extraVolumeMounts }}
+            {{- tpl (toYaml .) $ | nindent 12 -}}
+            {{- end }}
       {{- with .Values.server.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -82,3 +85,6 @@ spec:
             defaultMode: 420
             name: {{ include "buildfarm.fullname" . }}-server-log-props
           name: server-log-props
+        {{- with .Values.server.extraVolumes }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}


### PR DESCRIPTION
allow to add extraVolumes / extraVolumeMounts to the server, this can be used for `redisPasswordFile` as a example.