### PR TITLE
hide redis password in logs if its part of the RedisUri

### DIFF
--- a/src/main/java/build/buildfarm/common/config/Backplane.java
+++ b/src/main/java/build/buildfarm/common/config/Backplane.java
@@ -83,14 +83,18 @@ public class Backplane {
     if (uri == null) {
       return null;
     }
-    URI redisProperUri = URI.create(uri);
-
-    String password = JedisURIHelper.getPassword(redisProperUri);
-    if (Strings.isNullOrEmpty(password)) {
+    try {
+      URI redisProperUri = URI.create(uri);
+      String password = JedisURIHelper.getPassword(redisProperUri);
+      if (Strings.isNullOrEmpty(password)) {
+        return uri;
+      }
+      return uri.replace(password, "<HIDDEN>");
+    } catch (ArrayIndexOutOfBoundsException e) {
+      // JedisURIHelper.getPassword did not find the password (e.g. only username in
+      // uri.getUserInfo)
       return uri;
     }
-
-    return uri.replace(password, "<HIDDEN>");
   }
 
   /**
@@ -116,9 +120,14 @@ public class Backplane {
     if (r == null) {
       return null;
     }
-    URI redisProperUri = URI.create(r);
-    if (!Strings.isNullOrEmpty(JedisURIHelper.getPassword(redisProperUri))) {
-      return JedisURIHelper.getPassword(redisProperUri);
+    try {
+      URI redisProperUri = URI.create(r);
+      if (!Strings.isNullOrEmpty(JedisURIHelper.getPassword(redisProperUri))) {
+        return JedisURIHelper.getPassword(redisProperUri);
+      }
+    } catch (ArrayIndexOutOfBoundsException e) {
+      // JedisURIHelper.getPassword did not find the password (e.g. only username in
+      // uri.getUserInfo)
     }
 
     if (!Strings.isNullOrEmpty(redisCredentialFile)) {

--- a/src/main/java/build/buildfarm/common/config/Backplane.java
+++ b/src/main/java/build/buildfarm/common/config/Backplane.java
@@ -74,6 +74,26 @@ public class Backplane {
   private long priorityPollIntervalMillis = 100;
 
   /**
+   * This function is used to print the URI in logs.
+   *
+   * @return The redis URI but the password will be hidden, or <c>null</c> if unset.
+   */
+  public @Nullable String getRedisUriMasked() {
+    String uri = getRedisUri();
+    if (uri == null) {
+      return null;
+    }
+    URI redisProperUri = URI.create(uri);
+
+    String password = JedisURIHelper.getPassword(redisProperUri);
+    if (Strings.isNullOrEmpty(password)) {
+      return uri;
+    }
+
+    return uri.replace(password, "<HIDDEN>");
+  }
+
+  /**
    * @return The redis username, or <c>null</c> if unset.
    */
   public @Nullable String getRedisUsername() {

--- a/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
+++ b/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
@@ -239,7 +239,8 @@ public final class BuildfarmConfigs {
     // use environment override (useful for containerized deployment)
     if (!Strings.isNullOrEmpty(System.getenv("REDIS_URI"))) {
       configs.getBackplane().setRedisUri(System.getenv("REDIS_URI"));
-      log.info(String.format("RedisUri modified to %s", configs.getBackplane().getRedisUri()));
+      log.info(
+          String.format("RedisUri modified to %s", configs.getBackplane().getRedisUriMasked()));
     }
   }
 

--- a/src/test/java/build/buildfarm/common/config/BackplaneTest.java
+++ b/src/test/java/build/buildfarm/common/config/BackplaneTest.java
@@ -39,6 +39,9 @@ public class BackplaneTest {
     String testRedisUri = "redis://user:pass1@redisHost.redisDomain";
     b.setRedisUri(testRedisUri);
     assertThat(b.getRedisPassword()).isEqualTo("pass1");
+
+    b.setRedisUri("redis://user@redisHost.redisDomain");
+    assertThat(b.getRedisPassword()).isEqualTo(null);
   }
 
   /**
@@ -50,5 +53,22 @@ public class BackplaneTest {
     b.setRedisUri("redis://user:pass1@redisHost.redisDomain");
     b.setRedisPassword("pass2");
     assertThat(b.getRedisPassword()).isEqualTo("pass1");
+  }
+
+  /** Test that the `getRedisUriMasked` function returns the URI with the password hidden */
+  @Test
+  public void testGetRedisUriMasked() {
+    Backplane b = new Backplane();
+    b.setRedisUri("redis://user:pass1@redisHost.redisDomain");
+    assertThat(b.getRedisUriMasked()).isEqualTo("redis://user:<HIDDEN>@redisHost.redisDomain");
+
+    b.setRedisUri("redis://:pass1@redisHost.redisDomain");
+    assertThat(b.getRedisUriMasked()).isEqualTo("redis://:<HIDDEN>@redisHost.redisDomain");
+
+    b.setRedisUri("redis://user@redisHost.redisDomain");
+    assertThat(b.getRedisUriMasked()).isEqualTo("redis://user@redisHost.redisDomain");
+
+    b.setRedisUri("redis://redisHost.redisDomain");
+    assertThat(b.getRedisUriMasked()).isEqualTo("redis://redisHost.redisDomain");
   }
 }


### PR DESCRIPTION
This hides the redis password if its for example part of the REDIS_URI env.

old:

```
$ REDIS_URI="redis://123:pw@localhost:456" bazel run //src/main/java/build/buildfarm:buildfarm-server -- $PWD/examples/config.minimal.yml

....
Oct 24, 2024 11:39:31 AM build.buildfarm.common.config.BuildfarmConfigs adjustRedisUri
INFO: RedisUri modified to redis://123:pw@localhost:456
....

```

new:

```
$ REDIS_URI="redis://123:pw@localhost:456" bazel run //src/main/java/build/buildfarm:buildfarm-server -- $PWD/examples/config.minimal.yml

....
Oct 24, 2024 11:40:17 AM build.buildfarm.common.config.BuildfarmConfigs adjustRedisUri
INFO: RedisUri modified to redis://123:<HIDDEN>@localhost:456
....
```
