### PR TITLE
Isolate dequeue manipulations to specific queue

### DIFF
--- a/src/main/java/build/buildfarm/common/Queue.java
+++ b/src/main/java/build/buildfarm/common/Queue.java
@@ -22,9 +22,9 @@ public interface Queue<E> {
   Supplier<Long> size(AbstractPipeline pipeline);
 
   // maybe switch to iterator?
-  void visit(StringVisitor visitor);
+  void visit(Visitor<String> visitor);
 
-  void visitDequeue(StringVisitor visitor);
+  void visitDequeue(Visitor<String> visitor);
 
   boolean removeFromDequeue(E e);
 }

--- a/src/main/java/build/buildfarm/common/Visitor.java
+++ b/src/main/java/build/buildfarm/common/Visitor.java
@@ -15,15 +15,14 @@
 package build.buildfarm.common;
 
 /**
- * @class StringVisitor
- * @brief A string visitor.
- * @details Used to visit strings in a generic context.
+ * @class Visitor
+ * @brief A type visitor.
+ * @details Used to visit types in a generic context.
  */
-public abstract class StringVisitor {
+public interface Visitor<T> {
   /**
    * @brief The visit interface to be implemented.
-   * @details Inherited classes but implement visit.
-   * @param str The visited string.
+   * @param value The visited value.
    */
-  public abstract void visit(String str);
+  void visit(T t);
 }

--- a/src/main/java/build/buildfarm/common/redis/BalancedRedisQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/BalancedRedisQueue.java
@@ -17,7 +17,7 @@ package build.buildfarm.common.redis;
 import static com.google.common.collect.Iterables.transform;
 
 import build.buildfarm.common.Queue;
-import build.buildfarm.common.StringVisitor;
+import build.buildfarm.common.Visitor;
 import build.buildfarm.v1test.QueueStatus;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
@@ -32,6 +32,7 @@ import java.util.concurrent.Future;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import lombok.Data;
 import lombok.Getter;
 import redis.clients.jedis.AbstractPipeline;
 import redis.clients.jedis.Connection;
@@ -54,6 +55,27 @@ public class BalancedRedisQueue {
   private static final Duration START_TIMEOUT = Duration.ofSeconds(1);
 
   private static final Duration MAX_TIMEOUT = Duration.ofSeconds(8);
+
+  @Data
+  public static final class BalancedQueueEntry {
+    private final String queue;
+    private final String value;
+
+    BalancedQueueEntry(String queue, String value) {
+      this.queue = queue;
+      this.value = value;
+    }
+  }
+
+  private static Visitor<String> createBalancedQueueVisitor(
+      String queue, Visitor<BalancedQueueEntry> visitor) {
+    return new Visitor<>() {
+      @Override
+      public void visit(String value) {
+        visitor.visit(new BalancedQueueEntry(queue, value));
+      }
+    };
+  }
 
   /**
    * @field name
@@ -173,12 +195,11 @@ public class BalancedRedisQueue {
    * @return Whether or not the value was removed.
    * @note Suggested return identifier: wasRemoved.
    */
-  public boolean removeFromDequeue(UnifiedJedis unified, String val) {
-    for (String queue : partialIterationQueueOrder()) {
-      try (Jedis jedis = getJedisFromKey(unified, queue)) {
-        if (queueDecorator.decorate(jedis, queue).removeFromDequeue(val)) {
-          return true;
-        }
+  public boolean removeFromDequeue(UnifiedJedis unified, BalancedQueueEntry balancedQueueEntry) {
+    String queue = balancedQueueEntry.getQueue();
+    try (Jedis jedis = getJedisFromKey(unified, queue)) {
+      if (queueDecorator.decorate(jedis, queue).removeFromDequeue(balancedQueueEntry.getValue())) {
+        return true;
       }
     }
     return false;
@@ -216,12 +237,16 @@ public class BalancedRedisQueue {
     }
   }
 
-  public String take(UnifiedJedis unified, Duration timeout, ExecutorService service)
-      throws InterruptedException {
+  public @Nullable BalancedQueueEntry take(
+      UnifiedJedis unified, Duration timeout, ExecutorService service) throws InterruptedException {
     String queueName = queues.get(roundRobinPopIndex());
     try (Jedis jedis = getJedisFromKey(unified, queueName)) {
       Queue<String> queue = queueDecorator.decorate(jedis, queueName);
-      return take(jedis, queue, timeout, service);
+      String value = take(jedis, queue, timeout, service);
+      if (value == null) {
+        return null;
+      }
+      return new BalancedQueueEntry(queueName, value);
     }
   }
 
@@ -233,7 +258,8 @@ public class BalancedRedisQueue {
    * @return The value of the transfered element. null if the thread was interrupted.
    * @note Suggested return identifier: val.
    */
-  public String take(UnifiedJedis unified, ExecutorService service) throws InterruptedException {
+  public BalancedQueueEntry take(UnifiedJedis unified, ExecutorService service)
+      throws InterruptedException {
     // The conditions of this algorithm are as followed:
     // - from a client's perspective we want to block indefinitely.
     //   (so this function should not return null under any normal circumstances.)
@@ -269,7 +295,7 @@ public class BalancedRedisQueue {
       }
       // return if found
       if (val != null) {
-        return val;
+        return new BalancedQueueEntry(queueName, val);
       }
 
       // not quite immediate yet...
@@ -310,10 +336,14 @@ public class BalancedRedisQueue {
    * @return The value of the transfered element. null if queue is empty or thread was interrupted.
    * @note Suggested return identifier: val.
    */
-  public @Nullable String poll(UnifiedJedis unified) {
+  public @Nullable BalancedQueueEntry poll(UnifiedJedis unified) {
     String queue = queues.get(roundRobinPopIndex());
     try (Jedis jedis = getJedisFromKey(unified, queue)) {
-      return queueDecorator.decorate(jedis, queue).poll();
+      String value = queueDecorator.decorate(jedis, queue).poll();
+      if (value == null) {
+        return null;
+      }
+      return new BalancedQueueEntry(queue, value);
     }
   }
 
@@ -437,10 +467,10 @@ public class BalancedRedisQueue {
    * @details Enacts a visitor over each element in the queue.
    * @param visitor A visitor for each visited element in the queue.
    */
-  public void visit(UnifiedJedis unified, StringVisitor visitor) {
+  public void visit(UnifiedJedis unified, Visitor<BalancedQueueEntry> visitor) {
     for (String queue : fullIterationQueueOrder()) {
       try (Jedis jedis = getJedisFromKey(unified, queue)) {
-        queueDecorator.decorate(jedis, queue).visit(visitor);
+        queueDecorator.decorate(jedis, queue).visit(createBalancedQueueVisitor(queue, visitor));
       }
     }
   }
@@ -450,10 +480,12 @@ public class BalancedRedisQueue {
    * @details Enacts a visitor over each element in the dequeue.
    * @param visitor A visitor for each visited element in the queue.
    */
-  public void visitDequeue(UnifiedJedis unified, StringVisitor visitor) {
+  public void visitDequeue(UnifiedJedis unified, Visitor<BalancedQueueEntry> visitor) {
     for (String queue : fullIterationQueueOrder()) {
       try (Jedis jedis = getJedisFromKey(unified, queue)) {
-        queueDecorator.decorate(jedis, queue).visitDequeue(visitor);
+        queueDecorator
+            .decorate(jedis, queue)
+            .visitDequeue(createBalancedQueueVisitor(queue, visitor));
       }
     }
   }

--- a/src/main/java/build/buildfarm/common/redis/RedisPriorityQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisPriorityQueue.java
@@ -15,7 +15,7 @@
 package build.buildfarm.common.redis;
 
 import build.buildfarm.common.Queue;
-import build.buildfarm.common.StringVisitor;
+import build.buildfarm.common.Visitor;
 import com.google.common.collect.ImmutableList;
 import java.time.Clock;
 import java.time.Duration;
@@ -225,7 +225,7 @@ public class RedisPriorityQueue implements Queue<String> {
    * @note Overloaded.
    */
   @Override
-  public void visit(StringVisitor visitor) {
+  public void visit(Visitor<String> visitor) {
     visit(name, visitor);
   }
 
@@ -235,7 +235,7 @@ public class RedisPriorityQueue implements Queue<String> {
    * @param visitor A visitor for each visited element in the queue.
    */
   @Override
-  public void visitDequeue(StringVisitor visitor) {
+  public void visitDequeue(Visitor<String> visitor) {
     int listPageSize = 10000;
     int index = 0;
     int nextIndex = listPageSize;
@@ -258,7 +258,7 @@ public class RedisPriorityQueue implements Queue<String> {
    * @param visitor A visitor for each visited element in the queue.
    * @note Overloaded.
    */
-  private void visit(String queueName, StringVisitor visitor) {
+  private void visit(String queueName, Visitor<String> visitor) {
     int listPageSize = 10000;
     int index = 0;
     int nextIndex = listPageSize;

--- a/src/main/java/build/buildfarm/common/redis/RedisQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisQueue.java
@@ -18,7 +18,7 @@ import static redis.clients.jedis.args.ListDirection.LEFT;
 import static redis.clients.jedis.args.ListDirection.RIGHT;
 
 import build.buildfarm.common.Queue;
-import build.buildfarm.common.StringVisitor;
+import build.buildfarm.common.Visitor;
 import java.time.Duration;
 import java.util.List;
 import java.util.function.Supplier;
@@ -174,7 +174,7 @@ public class RedisQueue implements Queue<String> {
    * @param visitor A visitor for each visited element in the queue.
    * @note Overloaded.
    */
-  public void visit(StringVisitor visitor) {
+  public void visit(Visitor<String> visitor) {
     visit(name, visitor);
   }
 
@@ -183,7 +183,7 @@ public class RedisQueue implements Queue<String> {
    * @details Enacts a visitor over each element in the dequeue.
    * @param visitor A visitor for each visited element in the queue.
    */
-  public void visitDequeue(StringVisitor visitor) {
+  public void visitDequeue(Visitor<String> visitor) {
     visit(getDequeueName(), visitor);
   }
 
@@ -194,7 +194,7 @@ public class RedisQueue implements Queue<String> {
    * @param visitor A visitor for each visited element in the queue.
    * @note Overloaded.
    */
-  private void visit(String queueName, StringVisitor visitor) {
+  private void visit(String queueName, Visitor<String> visitor) {
     int index = 0;
     int nextIndex = listPageSize;
     List<String> entries;

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -32,13 +32,15 @@ import build.buildfarm.common.CasIndexResults;
 import build.buildfarm.common.CasIndexSettings;
 import build.buildfarm.common.DigestUtil;
 import build.buildfarm.common.DigestUtil.ActionKey;
-import build.buildfarm.common.StringVisitor;
 import build.buildfarm.common.Time;
+import build.buildfarm.common.Visitor;
 import build.buildfarm.common.Watcher;
 import build.buildfarm.common.WorkerIndexer;
 import build.buildfarm.common.config.BuildfarmConfigs;
 import build.buildfarm.common.function.InterruptingRunnable;
+import build.buildfarm.common.redis.BalancedRedisQueue.BalancedQueueEntry;
 import build.buildfarm.common.redis.RedisClient;
+import build.buildfarm.instance.shard.ExecutionQueue.ExecutionQueueEntry;
 import build.buildfarm.instance.shard.RedisShardSubscriber.TimedWatchFuture;
 import build.buildfarm.v1test.BackplaneStatus;
 import build.buildfarm.v1test.Digest;
@@ -178,28 +180,15 @@ public class RedisShardBackplane implements Backplane {
     this.onUnsubscribe = onUnsubscribe;
   }
 
-  abstract static class QueueEntryListVisitor extends StringVisitor {
-    protected abstract void visit(QueueEntry queueEntry, String queueEntryJson);
+  abstract static class ExecuteEntryListVisitor implements Visitor<BalancedQueueEntry> {
+    protected abstract void visit(ExecuteEntry executeEntry, BalancedQueueEntry balancedQueueEntry);
 
-    public void visit(String entry) {
-      QueueEntry.Builder queueEntry = QueueEntry.newBuilder();
-      try {
-        JsonFormat.parser().merge(entry, queueEntry);
-        visit(queueEntry.build(), entry);
-      } catch (InvalidProtocolBufferException e) {
-        log.log(Level.SEVERE, "invalid QueueEntry json: " + entry, e);
-      }
-    }
-  }
-
-  abstract static class ExecuteEntryListVisitor extends StringVisitor {
-    protected abstract void visit(ExecuteEntry executeEntry, String executeEntryJson);
-
-    public void visit(String entry) {
+    public void visit(BalancedQueueEntry balancedQueueEntry) {
+      String entry = balancedQueueEntry.getValue();
       ExecuteEntry.Builder executeEntry = ExecuteEntry.newBuilder();
       try {
         JsonFormat.parser().merge(entry, executeEntry);
-        visit(executeEntry.build(), entry);
+        visit(executeEntry.build(), balancedQueueEntry);
       } catch (InvalidProtocolBufferException e) {
         log.log(Level.FINER, "invalid ExecuteEntry json: " + entry, e);
       }
@@ -222,7 +211,7 @@ public class RedisShardBackplane implements Backplane {
         jedis,
         new ExecuteEntryListVisitor() {
           @Override
-          protected void visit(ExecuteEntry executeEntry, String executeEntryJson) {
+          protected void visit(ExecuteEntry executeEntry, BalancedQueueEntry balancedQueueEntry) {
             String executionName = executeEntry.getOperationName();
             String value = state.processingExecutions.get(jedis, executionName);
             long processingTimeout_ms = configs.getBackplane().getProcessingTimeoutMillis();
@@ -245,7 +234,7 @@ public class RedisShardBackplane implements Backplane {
             if (now.isBefore(expiresAt)) {
               onOperationName.accept(executionName);
             } else {
-              if (state.prequeue.removeFromDequeue(jedis, executeEntryJson)) {
+              if (state.prequeue.removeFromDequeue(jedis, balancedQueueEntry)) {
                 state.processingExecutions.remove(jedis, executionName);
               }
             }
@@ -256,9 +245,10 @@ public class RedisShardBackplane implements Backplane {
   private void scanDispatching(UnifiedJedis jedis, Consumer<String> onOperationName, Instant now) {
     state.executionQueue.visitDequeue(
         jedis,
-        new QueueEntryListVisitor() {
+        new Visitor<>() {
           @Override
-          protected void visit(QueueEntry queueEntry, String queueEntryJson) {
+          public void visit(ExecutionQueueEntry executionQueueEntry) {
+            QueueEntry queueEntry = executionQueueEntry.getQueueEntry();
             String executionName = queueEntry.getExecuteEntry().getOperationName();
             String value = state.dispatchingExecutions.get(jedis, executionName);
             long dispatchingTimeout_ms = configs.getBackplane().getDispatchingTimeoutMillis();
@@ -282,7 +272,7 @@ public class RedisShardBackplane implements Backplane {
             if (now.isBefore(expiresAt)) {
               onOperationName.accept(executionName);
             } else {
-              if (state.executionQueue.removeFromDequeue(jedis, queueEntryJson)) {
+              if (state.executionQueue.removeFromDequeue(jedis, executionQueueEntry)) {
                 state.dispatchingExecutions.remove(jedis, executionName);
               }
             }
@@ -295,7 +285,7 @@ public class RedisShardBackplane implements Backplane {
         jedis,
         new ExecuteEntryListVisitor() {
           @Override
-          protected void visit(ExecuteEntry executeEntry, String executeEntryJson) {
+          protected void visit(ExecuteEntry executeEntry, BalancedQueueEntry executeEntryJson) {
             onOperationName.accept(executeEntry.getOperationName());
           }
         });
@@ -304,9 +294,10 @@ public class RedisShardBackplane implements Backplane {
   private void scanQueue(UnifiedJedis jedis, Consumer<String> onOperationName) {
     state.executionQueue.visit(
         jedis,
-        new QueueEntryListVisitor() {
+        new Visitor<>() {
           @Override
-          protected void visit(QueueEntry queueEntry, String queueEntryJson) {
+          public void visit(ExecutionQueueEntry executionQueueEntry) {
+            QueueEntry queueEntry = executionQueueEntry.getQueueEntry();
             onOperationName.accept(queueEntry.getExecuteEntry().getOperationName());
           }
         });
@@ -378,27 +369,23 @@ public class RedisShardBackplane implements Backplane {
   }
 
   void publish(
-      UnifiedJedis jedis,
-      String channel,
-      Instant effectiveAt,
-      OperationChange.Builder operationChange) {
+      Consumer<String> onMessage, Instant effectiveAt, OperationChange.Builder operationChange) {
     try {
       String operationChangeJson =
           printOperationChange(
               operationChange.setEffectiveAt(toTimestamp(effectiveAt)).setSource(source).build());
-      jedis.publish(channel, operationChangeJson);
+      onMessage.accept(operationChangeJson);
     } catch (InvalidProtocolBufferException e) {
       log.log(Level.SEVERE, "error printing operation change", e);
       // very unlikely, printer would have to fail
     }
   }
 
-  void publishReset(UnifiedJedis jedis, Operation operation) {
+  void publishReset(Consumer<String> onMessage, Operation operation) {
     Instant effectiveAt = Instant.now();
     Instant expiresAt = nextExpiresAt(effectiveAt);
     publish(
-        jedis,
-        executionChannel(operation.getName()),
+        onMessage,
         Instant.now(),
         OperationChange.newBuilder()
             .setReset(
@@ -406,6 +393,16 @@ public class RedisShardBackplane implements Backplane {
                     .setExpiresAt(toTimestamp(expiresAt))
                     .setOperation(operation)
                     .build()));
+  }
+
+  void publishReset(AbstractPipeline pipeline, Operation operation) {
+    String channel = executionChannel(operation.getName());
+    publishReset(message -> pipeline.publish(channel, message), operation);
+  }
+
+  void publishReset(UnifiedJedis jedis, Operation operation) {
+    String channel = executionChannel(operation.getName());
+    publishReset(message -> jedis.publish(channel, message), operation);
   }
 
   static Timestamp toTimestamp(Instant instant) {
@@ -417,8 +414,7 @@ public class RedisShardBackplane implements Backplane {
 
   void publishExpiration(UnifiedJedis jedis, String channel, Instant effectiveAt) {
     publish(
-        jedis,
-        channel,
+        message -> jedis.publish(channel, message),
         effectiveAt,
         OperationChange.newBuilder()
             .setExpire(OperationChange.Expire.newBuilder().setForce(false).build()));
@@ -1120,14 +1116,14 @@ public class RedisShardBackplane implements Backplane {
   }
 
   private ExecuteEntry deprequeueOperation(UnifiedJedis jedis) throws InterruptedException {
-    String executeEntryJson = state.prequeue.take(jedis, dequeueService);
-    if (executeEntryJson == null) {
+    BalancedQueueEntry balancedQueueEntry = state.prequeue.take(jedis, dequeueService);
+    if (balancedQueueEntry == null) {
       return null;
     }
 
     ExecuteEntry.Builder executeEntryBuilder = ExecuteEntry.newBuilder();
     try {
-      JsonFormat.parser().merge(executeEntryJson, executeEntryBuilder);
+      JsonFormat.parser().merge(balancedQueueEntry.getValue(), executeEntryBuilder);
       ExecuteEntry executeEntry = executeEntryBuilder.build();
       String executionName = executeEntry.getOperationName();
 
@@ -1136,7 +1132,7 @@ public class RedisShardBackplane implements Backplane {
       publishReset(jedis, operation);
 
       // destroy the processing entry and ttl
-      if (!state.prequeue.removeFromDequeue(jedis, executeEntryJson)) {
+      if (!state.prequeue.removeFromDequeue(jedis, balancedQueueEntry)) {
         log.log(
             Level.SEVERE,
             format("could not remove %s from %s", executionName, state.prequeue.getDequeueName()));
@@ -1158,20 +1154,13 @@ public class RedisShardBackplane implements Backplane {
 
   private @Nullable QueueEntry dispatchOperation(
       UnifiedJedis jedis, List<Platform.Property> provisions) throws InterruptedException {
-    String queueEntryJson = state.executionQueue.dequeue(jedis, provisions, dequeueService);
-    if (queueEntryJson == null) {
+    ExecutionQueueEntry executionQueueEntry =
+        state.executionQueue.dequeue(jedis, provisions, dequeueService);
+    if (executionQueueEntry == null) {
       return null;
     }
 
-    QueueEntry.Builder queueEntryBuilder = QueueEntry.newBuilder();
-    try {
-      JsonFormat.parser().merge(queueEntryJson, queueEntryBuilder);
-    } catch (InvalidProtocolBufferException e) {
-      log.log(Level.SEVERE, "error parsing queue entry", e);
-      return null;
-    }
-    QueueEntry queueEntry = queueEntryBuilder.build();
-
+    QueueEntry queueEntry = executionQueueEntry.getQueueEntry();
     String executionName = queueEntry.getExecuteEntry().getOperationName();
     Operation operation = keepaliveExecution(executionName);
     publishReset(jedis, operation);
@@ -1180,32 +1169,20 @@ public class RedisShardBackplane implements Backplane {
         System.currentTimeMillis() + configs.getBackplane().getDispatchingTimeoutMillis();
     DispatchedOperation o =
         DispatchedOperation.newBuilder().setQueueEntry(queueEntry).setRequeueAt(requeueAt).build();
-    boolean success = false;
     try {
       String dispatchedOperationJson = JsonFormat.printer().print(o);
 
-      /* if the operation is already in the dispatch list, fail the dispatch */
-      success =
-          state.dispatchedExecutions.insertIfMissing(jedis, executionName, dispatchedOperationJson);
+      state.dispatchedExecutions.insertIfMissing(jedis, executionName, dispatchedOperationJson);
     } catch (InvalidProtocolBufferException e) {
       log.log(Level.SEVERE, "error printing dispatched operation", e);
       // very unlikely, printer would have to fail
     }
 
-    if (success) {
-      if (!state.executionQueue.removeFromDequeue(jedis, queueEntryJson)) {
-        log.log(
-            Level.WARNING,
-            format(
-                "operation %s was missing in %s, may be orphaned",
-                executionName, state.executionQueue.getDequeueName()));
-      }
-      state.dispatchingExecutions.remove(jedis, executionName);
+    state.executionQueue.removeFromDequeue(jedis, executionQueueEntry);
+    state.dispatchingExecutions.remove(jedis, executionName);
 
-      // Return an entry so that if it needs re-queued, it will have the correct "requeue attempts".
-      return queueEntryBuilder.setRequeueAttempts(queueEntry.getRequeueAttempts() + 1).build();
-    }
-    return null;
+    // Return an entry so that if it needs re-queued, it will have the correct "requeue attempts".
+    return queueEntry.toBuilder().setRequeueAttempts(queueEntry.getRequeueAttempts() + 1).build();
   }
 
   @SuppressWarnings("ConstantConditions")

--- a/src/test/java/build/buildfarm/common/redis/BalancedRedisQueueTest.java
+++ b/src/test/java/build/buildfarm/common/redis/BalancedRedisQueueTest.java
@@ -18,8 +18,9 @@ import static com.google.common.truth.Truth.assertThat;
 import static java.util.concurrent.Executors.newSingleThreadExecutor;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-import build.buildfarm.common.StringVisitor;
+import build.buildfarm.common.Visitor;
 import build.buildfarm.common.config.BuildfarmConfigs;
+import build.buildfarm.common.redis.BalancedRedisQueue.BalancedQueueEntry;
 import build.buildfarm.instance.shard.JedisClusterFactory;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
@@ -169,7 +170,7 @@ public class BalancedRedisQueueTest {
     BalancedRedisQueue queue = new BalancedRedisQueue("test", hashtags, RedisQueue::decorate);
 
     // ACT
-    Boolean success = queue.removeFromDequeue(jedis, "foo");
+    Boolean success = queue.removeFromDequeue(jedis, new BalancedQueueEntry("test", "foo"));
 
     // ASSERT
     assertThat(success).isFalse();
@@ -193,7 +194,7 @@ public class BalancedRedisQueueTest {
     queue.take(jedis, service);
     queue.take(jedis, service);
     service.shutdown();
-    Boolean success = queue.removeFromDequeue(jedis, "baz");
+    Boolean success = queue.removeFromDequeue(jedis, new BalancedQueueEntry("test", "baz"));
 
     // ASSERT
     assertThat(service.awaitTermination(0, SECONDS)).isTrue();
@@ -219,7 +220,7 @@ public class BalancedRedisQueueTest {
     queue.take(jedis, service);
     queue.take(jedis, service);
     service.shutdown();
-    Boolean success = queue.removeFromDequeue(jedis, "bar");
+    Boolean success = queue.removeFromDequeue(jedis, new BalancedQueueEntry("test", "bar"));
 
     // ASSERT
     assertThat(service.awaitTermination(0, SECONDS)).isTrue();
@@ -457,10 +458,10 @@ public class BalancedRedisQueueTest {
 
     // ACT
     List<String> visited = new ArrayList<>();
-    StringVisitor visitor =
-        new StringVisitor() {
-          public void visit(String entry) {
-            visited.add(entry);
+    Visitor<BalancedQueueEntry> visitor =
+        new Visitor<>() {
+          public void visit(BalancedQueueEntry entry) {
+            visited.add(entry.getValue());
           }
         };
     queue.visit(jedis, visitor);
@@ -497,10 +498,10 @@ public class BalancedRedisQueueTest {
 
     // ACT
     List<String> visited = new ArrayList<>();
-    StringVisitor visitor =
-        new StringVisitor() {
-          public void visit(String entry) {
-            visited.add(entry);
+    Visitor<BalancedQueueEntry> visitor =
+        new Visitor<>() {
+          public void visit(BalancedQueueEntry entry) {
+            visited.add(entry.getValue());
           }
         };
     queue.visit(jedis, visitor);

--- a/src/test/java/build/buildfarm/common/redis/RedisPriorityQueueMockTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisPriorityQueueMockTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import build.buildfarm.common.StringVisitor;
+import build.buildfarm.common.Visitor;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -295,8 +295,8 @@ public class RedisPriorityQueueMockTest {
 
     // ACT
     List<String> visited = new ArrayList<>();
-    StringVisitor visitor =
-        new StringVisitor() {
+    Visitor<String> visitor =
+        new Visitor<>() {
           public void visit(String entry) {
             visited.add(entry);
           }
@@ -338,8 +338,8 @@ public class RedisPriorityQueueMockTest {
 
     // ACT
     List<String> visited = new ArrayList<>();
-    StringVisitor visitor =
-        new StringVisitor() {
+    Visitor<String> visitor =
+        new Visitor<>() {
           public void visit(String entry) {
             visited.add(entry);
           }

--- a/src/test/java/build/buildfarm/common/redis/RedisPriorityQueueTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisPriorityQueueTest.java
@@ -19,7 +19,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 
-import build.buildfarm.common.StringVisitor;
+import build.buildfarm.common.Visitor;
 import build.buildfarm.common.config.BuildfarmConfigs;
 import build.buildfarm.instance.shard.JedisClusterFactory;
 import com.google.common.base.Stopwatch;
@@ -327,8 +327,8 @@ public class RedisPriorityQueueTest {
 
     // ACT
     List<String> visited = new ArrayList<>();
-    StringVisitor visitor =
-        new StringVisitor() {
+    Visitor<String> visitor =
+        new Visitor<>() {
           public void visit(String entry) {
             visited.add(entry);
           }
@@ -360,8 +360,8 @@ public class RedisPriorityQueueTest {
 
     // ACT
     List<String> visited = new ArrayList<>();
-    StringVisitor visitor =
-        new StringVisitor() {
+    Visitor<String> visitor =
+        new Visitor<>() {
           public void visit(String entry) {
             visited.add(entry);
           }

--- a/src/test/java/build/buildfarm/common/redis/RedisQueueMockTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisQueueMockTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.when;
 import static redis.clients.jedis.args.ListDirection.LEFT;
 import static redis.clients.jedis.args.ListDirection.RIGHT;
 
-import build.buildfarm.common.StringVisitor;
+import build.buildfarm.common.Visitor;
 import com.google.common.collect.ImmutableList;
 import java.time.Duration;
 import org.junit.Before;
@@ -113,7 +113,7 @@ public class RedisQueueMockTest {
   }
 
   private void verifyVisitLRange(
-      String name, StringVisitor visitor, int listPageSize, Iterable<String> entries) {
+      String name, Visitor<String> visitor, int listPageSize, Iterable<String> entries) {
     int pageCount = listPageSize;
     int index = 0;
     int nextIndex = listPageSize;
@@ -138,7 +138,7 @@ public class RedisQueueMockTest {
     int listPageSize = 3;
     RedisQueue queue = new RedisQueue(redis, "test", listPageSize);
     arrangeVisitLRange("test", listPageSize, VISIT_ENTRIES);
-    StringVisitor visitor = mock(StringVisitor.class);
+    Visitor<String> visitor = mock(Visitor.class);
 
     queue.visit(visitor);
 
@@ -150,7 +150,7 @@ public class RedisQueueMockTest {
     int listPageSize = 3;
     RedisQueue queue = new RedisQueue(redis, "test", listPageSize);
     arrangeVisitLRange(queue.getDequeueName(), listPageSize, VISIT_ENTRIES);
-    StringVisitor visitor = mock(StringVisitor.class);
+    Visitor<String> visitor = mock(Visitor.class);
 
     queue.visitDequeue(visitor);
 

--- a/src/test/java/build/buildfarm/common/redis/RedisQueueTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisQueueTest.java
@@ -19,7 +19,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import build.buildfarm.common.StringVisitor;
+import build.buildfarm.common.Visitor;
 import build.buildfarm.common.config.BuildfarmConfigs;
 import build.buildfarm.instance.shard.JedisClusterFactory;
 import com.google.common.collect.ImmutableList;
@@ -171,7 +171,7 @@ public class RedisQueueTest {
     for (String entry : VISIT_ENTRIES) {
       redis.lpush("test", entry);
     }
-    StringVisitor visitor = mock(StringVisitor.class);
+    Visitor<String> visitor = mock(Visitor.class);
 
     queue.visit(visitor);
 
@@ -188,7 +188,7 @@ public class RedisQueueTest {
     for (String entry : VISIT_ENTRIES) {
       redis.lpush(queue.getDequeueName(), entry);
     }
-    StringVisitor visitor = mock(StringVisitor.class);
+    Visitor<String> visitor = mock(Visitor.class);
 
     queue.visitDequeue(visitor);
 


### PR DESCRIPTION
Removing dequeued executions from queues must be limited to the specific
queue target. This drastically reduces the # of dequeues observed in multi-
queue scenarios.