### PR TITLE
Pipeline dispatch redis activities

### DIFF
--- a/src/main/java/build/buildfarm/common/Queue.java
+++ b/src/main/java/build/buildfarm/common/Queue.java
@@ -27,4 +27,6 @@ public interface Queue<E> {
   void visitDequeue(Visitor<String> visitor);
 
   boolean removeFromDequeue(E e);
+
+  void removeFromDequeue(AbstractPipeline pipeline, E e);
 }

--- a/src/main/java/build/buildfarm/common/redis/BalancedRedisQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/BalancedRedisQueue.java
@@ -205,6 +205,12 @@ public class BalancedRedisQueue {
     return false;
   }
 
+  public void removeFromDequeue(AbstractPipeline pipeline, BalancedQueueEntry balancedQueueEntry) {
+    queueDecorator
+        .decorate(null, balancedQueueEntry.getQueue())
+        .removeFromDequeue(pipeline, balancedQueueEntry.getValue());
+  }
+
   private String take(Jedis jedis, Queue<String> queue, Duration timeout, ExecutorService service)
       throws InterruptedException {
     return interruptibleRequest(() -> queue.take(timeout), jedis::disconnect, service);

--- a/src/main/java/build/buildfarm/common/redis/RedisHashMap.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisHashMap.java
@@ -76,6 +76,10 @@ public class RedisHashMap {
     return jedis.hsetnx(name, key, value) == 1;
   }
 
+  public Response<Long> insertIfMissing(AbstractPipeline jedis, String key, String value) {
+    return jedis.hsetnx(name, key, value);
+  }
+
   /**
    * @brief Checks whether key exists
    * @details True if key exists. False if it does not.

--- a/src/main/java/build/buildfarm/common/redis/RedisMap.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisMap.java
@@ -130,6 +130,10 @@ public class RedisMap {
     jedis.del(createKeyName(key));
   }
 
+  public void remove(AbstractPipeline pipeline, String key) {
+    pipeline.del(createKeyName(key));
+  }
+
   /**
    * @brief Remove multiple keys from the map.
    * @details Done via pipeline.

--- a/src/main/java/build/buildfarm/common/redis/RedisPriorityQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisPriorityQueue.java
@@ -138,6 +138,11 @@ public class RedisPriorityQueue implements Queue<String> {
     return jedis.lrem(getDequeueName(), -1, val) != 0;
   }
 
+  @Override
+  public void removeFromDequeue(AbstractPipeline pipeline, String val) {
+    pipeline.lrem(getDequeueName(), -1, val);
+  }
+
   /**
    * @brief Remove all elements that match from queue.
    * @details Removes all matching elements from the queue and specifies whether it was removed.

--- a/src/main/java/build/buildfarm/common/redis/RedisQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisQueue.java
@@ -105,6 +105,11 @@ public class RedisQueue implements Queue<String> {
     return jedis.lrem(getDequeueName(), -1, val) != 0;
   }
 
+  @Override
+  public void removeFromDequeue(AbstractPipeline pipeline, String val) {
+    pipeline.lrem(getDequeueName(), -1, val);
+  }
+
   /**
    * @brief Remove all elements that match from queue.
    * @details Removes all matching elements from the queue and specifies whether it was removed.

--- a/src/main/java/build/buildfarm/instance/shard/ExecutionQueue.java
+++ b/src/main/java/build/buildfarm/instance/shard/ExecutionQueue.java
@@ -152,6 +152,10 @@ public class ExecutionQueue {
     return entry.getQueue().removeFromDequeue(jedis, entry.getBalancedQueueEntry());
   }
 
+  public static void removeFromDequeue(AbstractPipeline pipeline, ExecutionQueueEntry entry) {
+    entry.getQueue().removeFromDequeue(pipeline, entry.getBalancedQueueEntry());
+  }
+
   /**
    * @brief Visit each element in the queue.
    * @details Enacts a visitor over each element in the queue.


### PR DESCRIPTION
Prevent 'fire and forget' round trips to redis bottlenecks during
dispatch activity. A single choke point exists to ensure that the
execution is present in the dispatchedExecutions map before returning.
This could also be similarly futured to ensure sequencing with attempted
removal on completion.