### PR TITLE
Ensure tree directories are emitted with hashes

### DIFF
--- a/src/main/java/build/buildfarm/common/DigestPath.java
+++ b/src/main/java/build/buildfarm/common/DigestPath.java
@@ -1,0 +1,20 @@
+// Copyright 2024 The Buildfarm Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common;
+
+import build.buildfarm.v1test.Digest;
+import java.nio.file.Path;
+
+public record DigestPath(Digest digest, Path path) {}

--- a/src/main/java/build/buildfarm/common/DigestUtil.java
+++ b/src/main/java/build/buildfarm/common/DigestUtil.java
@@ -59,12 +59,13 @@ public class DigestUtil {
 
   public static final Map<DigestFunction.Value, Digest> empty =
       ImmutableMap.of(
-          DigestFunction.Value.MD5, DigestUtil.forHash("MD5").compute(ByteString.empty()),
-          DigestFunction.Value.SHA1, DigestUtil.forHash("SHA1").compute(ByteString.empty()),
-          DigestFunction.Value.SHA256, DigestUtil.forHash("SHA256").compute(ByteString.empty()),
-          DigestFunction.Value.SHA384, DigestUtil.forHash("SHA384").compute(ByteString.empty()),
-          DigestFunction.Value.SHA512, DigestUtil.forHash("SHA512").compute(ByteString.empty()),
-          DigestFunction.Value.BLAKE3, DigestUtil.forHash("BLAKE3").compute(ByteString.empty()));
+          DigestFunction.Value.MD5, DigestUtil.forHash("MD5").computeImpl(ByteString.empty()),
+          DigestFunction.Value.SHA1, DigestUtil.forHash("SHA1").computeImpl(ByteString.empty()),
+          DigestFunction.Value.SHA256, DigestUtil.forHash("SHA256").computeImpl(ByteString.empty()),
+          DigestFunction.Value.SHA384, DigestUtil.forHash("SHA384").computeImpl(ByteString.empty()),
+          DigestFunction.Value.SHA512, DigestUtil.forHash("SHA512").computeImpl(ByteString.empty()),
+          DigestFunction.Value.BLAKE3,
+              DigestUtil.forHash("BLAKE3").computeImpl(ByteString.empty()));
 
   /** Type of hash function to use for digesting blobs. */
   // The underlying HashFunctions are immutable and thread safe.
@@ -203,8 +204,12 @@ public class DigestUtil {
 
   public Digest compute(ByteString blob) {
     if (blob.size() == 0) {
-      return Digest.getDefaultInstance();
+      return empty();
     }
+    return computeImpl(blob);
+  }
+
+  private Digest computeImpl(ByteString blob) {
     return buildDigest(computeHash(blob).toString(), blob.size(), getDigestFunction());
   }
 

--- a/src/main/java/build/buildfarm/common/function/IOConsumer.java
+++ b/src/main/java/build/buildfarm/common/function/IOConsumer.java
@@ -1,0 +1,37 @@
+// Copyright 2024 The Buildfarm Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common.function;
+
+import java.io.IOException;
+
+/**
+ * Represents an operation that accepts a single input argument and returns no result, and may throw
+ * an IOException, implying that calls may perform I/O. Unlike most other functional interfaces,
+ * {@code IOConsumer} is expected to operate via side-effects.
+ *
+ * <p>This is a <a href="package-summary.html">functional interface</a> whose functional method is
+ * {@link #accept(Object)}.
+ *
+ * @param <T> the type of the input to the operation
+ */
+@FunctionalInterface
+public interface IOConsumer<T> {
+  /**
+   * Performs this I/O operation on the given argument.
+   *
+   * @param t the input argument
+   */
+  void accept(T t) throws IOException;
+}

--- a/src/main/java/build/buildfarm/worker/shard/TreeWalker.java
+++ b/src/main/java/build/buildfarm/worker/shard/TreeWalker.java
@@ -1,0 +1,178 @@
+// Copyright 2024 The Buildfarm Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker.shard;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.lang.String.format;
+
+import build.bazel.remote.execution.v2.Directory;
+import build.bazel.remote.execution.v2.DirectoryNode;
+import build.bazel.remote.execution.v2.FileNode;
+import build.bazel.remote.execution.v2.SymlinkNode;
+import build.bazel.remote.execution.v2.Tree;
+import build.buildfarm.common.DigestPath;
+import build.buildfarm.common.DigestUtil;
+import build.buildfarm.common.function.IOConsumer;
+import build.buildfarm.v1test.Digest;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Stack;
+import java.util.logging.Level;
+import lombok.extern.java.Log;
+
+/** May be used multiple times, but not threadsafe */
+@Log
+class TreeWalker extends SimpleFileVisitor<Path> {
+  private static final class OutputDirectoryContext {
+    private final List<FileNode> files = new ArrayList<>();
+    private final List<DirectoryNode> directories = new ArrayList<>();
+    private final List<SymlinkNode> symlinks = new ArrayList<>();
+
+    void addFile(FileNode fileNode) {
+      files.add(fileNode);
+    }
+
+    void addDirectory(DirectoryNode directoryNode) {
+      directories.add(directoryNode);
+    }
+
+    void addSymlink(SymlinkNode symlinkNode) {
+      symlinks.add(symlinkNode);
+    }
+
+    Directory toDirectory() {
+      files.sort(Comparator.comparing(FileNode::getName));
+      directories.sort(Comparator.comparing(DirectoryNode::getName));
+      symlinks.sort(Comparator.comparing(SymlinkNode::getName));
+      return Directory.newBuilder()
+          .addAllFiles(files)
+          .addAllDirectories(directories)
+          .addAllSymlinks(symlinks)
+          .build();
+    }
+  }
+
+  private final Stack<OutputDirectoryContext> path = new Stack<>();
+  private final boolean createSymlinkOutputs;
+  private final DigestUtil digestUtil;
+  private final IOConsumer<DigestPath> fileObserver;
+  private Tree.Builder treeBuilder = null;
+  private OutputDirectoryContext currentDirectory = null;
+  private Tree tree = null;
+  private Path root = null;
+
+  TreeWalker(
+      boolean createSymlinkOutputs, DigestUtil digestUtil, IOConsumer<DigestPath> fileObserver) {
+    this.createSymlinkOutputs = createSymlinkOutputs;
+    this.digestUtil = digestUtil;
+    this.fileObserver = fileObserver;
+  }
+
+  Tree getTree() {
+    // only valid after peforming a walk
+    return checkNotNull(tree);
+  }
+
+  @Override
+  public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+    if (createSymlinkOutputs && attrs.isSymbolicLink()) {
+      visitSymbolicLink(file);
+    } else {
+      visitRegularFile(file);
+    }
+    return FileVisitResult.CONTINUE;
+  }
+
+  private void visitSymbolicLink(Path file) throws IOException {
+    // TODO convert symlinks with absolute targets within execution root to relative ones
+    currentDirectory.addSymlink(
+        SymlinkNode.newBuilder()
+            .setName(file.getFileName().toString())
+            .setTarget(Files.readSymbolicLink(file).toString())
+            .build());
+  }
+
+  private void visitRegularFile(Path file) throws IOException {
+    Digest digest;
+    try {
+      // should we create symlink nodes in output?
+      // is buildstream trying to execute in a specific container??
+      // can get to NSFE for nonexistent symlinks
+      // can fail outright for a symlink to a directory
+      digest = digestUtil.compute(file);
+    } catch (NoSuchFileException e) {
+      log.log(
+          Level.SEVERE,
+          format(
+              "error visiting file %s under output dir %s",
+              root.relativize(file), root.toAbsolutePath()),
+          e);
+      return;
+    }
+
+    // should we cast to PosixFilePermissions and do gymnastics there for executable?
+
+    // TODO symlink per revision proposal
+    currentDirectory.addFile(
+        FileNode.newBuilder()
+            .setName(file.getFileName().toString())
+            .setDigest(DigestUtil.toDigest(digest))
+            .setIsExecutable(Files.isExecutable(file))
+            .build());
+    fileObserver.accept(new DigestPath(digest, file));
+  }
+
+  @Override
+  public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+    path.push(currentDirectory);
+    if (currentDirectory == null) {
+      // reset state when at root
+      treeBuilder = Tree.newBuilder();
+      root = dir;
+    }
+    currentDirectory = new OutputDirectoryContext();
+    return FileVisitResult.CONTINUE;
+  }
+
+  @Override
+  public FileVisitResult postVisitDirectory(Path dir, IOException exc) {
+    OutputDirectoryContext parentDirectory = path.pop();
+    Directory directory = currentDirectory.toDirectory();
+    if (parentDirectory == null) {
+      treeBuilder.setRoot(directory);
+      tree = treeBuilder.build();
+      treeBuilder = null;
+      root = null;
+    } else {
+      parentDirectory.addDirectory(
+          DirectoryNode.newBuilder()
+              .setName(dir.getFileName().toString())
+              // FIXME make one digestUtil for all
+              .setDigest(DigestUtil.toDigest(digestUtil.compute(directory)))
+              .build());
+      treeBuilder.addChildren(directory);
+    }
+    currentDirectory = parentDirectory;
+    return FileVisitResult.CONTINUE;
+  }
+}

--- a/src/test/java/build/buildfarm/common/DigestUtilTest.java
+++ b/src/test/java/build/buildfarm/common/DigestUtilTest.java
@@ -105,10 +105,11 @@ public class DigestUtilTest {
   }
 
   @Test
-  public void computeEmptyIsDefault() {
+  public void computeEmptyIsCachedEmpty() {
     DigestUtil digestUtil = new DigestUtil(HashFunction.BLAKE3);
     Digest digest = digestUtil.compute(ByteString.empty());
-    assertThat(digest == Digest.getDefaultInstance()).isTrue();
+    // reference comparison
+    assertThat(digest == digestUtil.empty()).isTrue();
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/build/buildfarm/worker/shard/TreeWalkerTest.java
+++ b/src/test/java/build/buildfarm/worker/shard/TreeWalkerTest.java
@@ -1,0 +1,132 @@
+// Copyright 2024 The Buildfarm Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker.shard;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import build.bazel.remote.execution.v2.Directory;
+import build.bazel.remote.execution.v2.DirectoryNode;
+import build.bazel.remote.execution.v2.FileNode;
+import build.bazel.remote.execution.v2.SymlinkNode;
+import build.bazel.remote.execution.v2.Tree;
+import build.buildfarm.common.DigestPath;
+import build.buildfarm.common.DigestUtil;
+import build.buildfarm.common.function.IOConsumer;
+import build.buildfarm.v1test.Digest;
+import com.google.common.collect.Iterables;
+import com.google.common.jimfs.Jimfs;
+import com.google.protobuf.ByteString;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TreeWalkerTest {
+  private final Path root = Iterables.getOnlyElement(Jimfs.newFileSystem().getRootDirectories());
+
+  @Test
+  public void treeShouldHaveHashedEmptyDirsInChildren() throws IOException {
+    // ensure that we have a clean topdir
+    Path treeRoot = root.resolve("tree_root");
+    Files.createDirectory(treeRoot);
+    Files.createDirectories(treeRoot.resolve("empty_subdir"));
+    DigestUtil digestUtil = DigestUtil.forHash("BLAKE3");
+    TreeWalker treeWalker =
+        new TreeWalker(/* createSymlinkOutputs= */ false, digestUtil, digestPath -> {});
+    Files.walkFileTree(treeRoot, treeWalker);
+    Tree tree = treeWalker.getTree();
+    DirectoryNode directoryNode = Iterables.getOnlyElement(tree.getRoot().getDirectoriesList());
+    assertThat(directoryNode.getName()).isEqualTo("empty_subdir");
+    Digest digest = digestUtil.toDigest(directoryNode.getDigest());
+    assertThat(digestUtil.compute(Iterables.getOnlyElement(tree.getChildrenList())))
+        .isEqualTo(digest);
+    assertThat(digest).isEqualTo(digestUtil.empty());
+    assertThat(digest.getHash().isEmpty()).isFalse();
+  }
+
+  @Test
+  public void visitsSymlinksAsFilesWhenConfigured() throws IOException {
+    DigestUtil digestUtil = DigestUtil.forHash("BLAKE3");
+    ByteString content = ByteString.copyFromUtf8("Hello, World");
+    Digest digest = digestUtil.compute(content);
+
+    IOConsumer<DigestPath> fileObserver = mock(IOConsumer.class);
+    TreeWalker treeWalker =
+        new TreeWalker(/* createSymlinkOutputs= */ false, digestUtil, fileObserver);
+    Path treeRoot = root.resolve("tree_root");
+    Files.createDirectory(treeRoot);
+    Path filePath = treeRoot.resolve("file");
+    try (OutputStream out = Files.newOutputStream(filePath)) {
+      content.writeTo(out);
+    }
+    Path symlinkPath = treeRoot.resolve("symlink_to_file");
+    Files.createSymbolicLink(symlinkPath, treeRoot.relativize(filePath));
+    Files.walkFileTree(treeRoot, treeWalker);
+    Tree tree = treeWalker.getTree();
+    Directory rootDirectory = tree.getRoot();
+    List<FileNode> files = rootDirectory.getFilesList();
+    assertThat(files.size()).isEqualTo(2);
+    assertThat(files.get(0).getDigest()).isEqualTo(files.get(1).getDigest());
+    assertThat(files.get(0).getName()).isEqualTo("file");
+    assertThat(files.get(1).getName()).isEqualTo("symlink_to_file");
+    assertThat(rootDirectory.getSymlinksCount()).isEqualTo(0);
+    verify(fileObserver, times(1)).accept(new DigestPath(digest, filePath));
+    verify(fileObserver, times(1)).accept(new DigestPath(digest, symlinkPath));
+  }
+
+  @Test
+  public void visitsSymlinksWhenConfigured() throws IOException {
+    DigestUtil digestUtil = DigestUtil.forHash("BLAKE3");
+
+    TreeWalker treeWalker =
+        new TreeWalker(/* createSymlinkOutputs= */ true, digestUtil, digestPath -> {});
+    Path treeRoot = root.resolve("tree_root");
+    Files.createDirectory(treeRoot);
+    Path filePath = treeRoot.resolve("file");
+    Files.createSymbolicLink(treeRoot.resolve("symlink"), treeRoot.relativize(filePath));
+    Files.walkFileTree(treeRoot, treeWalker);
+    Tree tree = treeWalker.getTree();
+    Directory rootDirectory = tree.getRoot();
+    SymlinkNode symlink = Iterables.getOnlyElement(rootDirectory.getSymlinksList());
+    assertThat(symlink.getName()).isEqualTo("symlink");
+    assertThat(symlink.getTarget()).isEqualTo("file");
+    assertThat(rootDirectory.getFilesCount()).isEqualTo(0);
+  }
+
+  @Test
+  public void ignoresDeadSymlinksWhenConfigured() throws IOException {
+    DigestUtil digestUtil = DigestUtil.forHash("BLAKE3");
+
+    TreeWalker treeWalker =
+        new TreeWalker(/* createSymlinkOutputs= */ false, digestUtil, digestPath -> {});
+    Path treeRoot = root.resolve("tree_root");
+    Files.createDirectory(treeRoot);
+    Path filePath = treeRoot.resolve("file");
+    Files.createSymbolicLink(treeRoot.resolve("dead_symlink"), treeRoot.relativize(filePath));
+    Files.walkFileTree(treeRoot, treeWalker);
+    Tree tree = treeWalker.getTree();
+    Directory rootDirectory = tree.getRoot();
+    assertThat(rootDirectory.getSymlinksCount()).isEqualTo(0);
+    assertThat(rootDirectory.getFilesCount()).isEqualTo(0);
+  }
+}


### PR DESCRIPTION
Adding multiple digest functions created many short-lived DigestUtils where efforts to reduce the number of instances of the empty digest for each digest function pushed the empty into the hash function enums. Failing to return the empty() digest, in favor of the digest default instance, resulted in incorrect presentation of directories in REAPI Trees, used in output directory execution results. We now test that a) the digest util always results in a compute()d cached empty() reference, and b) that Tree Directories will have digest references with hashes for all, including non-empty, directories present in the children list.
Fixes #1910