### PR TITLE
refactor: time

### DIFF
--- a/src/main/java/build/buildfarm/common/Time.java
+++ b/src/main/java/build/buildfarm/common/Time.java
@@ -37,8 +37,7 @@ public class Time {
    * @note Suggested return identifier: deadline.
    */
   public static Deadline toDeadline(Duration duration) {
-    return Deadline.after(
-        secondsToNanoseconds(duration.getSeconds()) + duration.getNanos(), TimeUnit.NANOSECONDS);
+    return Deadline.after(Durations.toNanos(duration), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -60,7 +59,7 @@ public class Time {
    * @note Suggested return identifier: nanoseconds.
    */
   public static long secondsToNanoseconds(long seconds) {
-    return seconds * 1000000000L;
+    return seconds * 1_000_000_000L;
   }
 
   /**

--- a/src/main/java/build/buildfarm/common/config/Backplane.java
+++ b/src/main/java/build/buildfarm/common/config/Backplane.java
@@ -67,7 +67,7 @@ public class Backplane {
    */
   private String redisCertificateAuthorityFile;
 
-  private int timeout = 10000;
+  private int timeout = 10000; // Milliseconds
   private String[] redisNodes = {};
   private int maxAttempts = 20;
   private boolean cacheCas = false;

--- a/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
@@ -2237,7 +2237,7 @@ public class ServerInstance extends NodeInstance {
               .setRequestMetadata(requestMetadata)
               .setStdoutStreamName(stdoutStreamName)
               .setStderrStreamName(stderrStreamName)
-              .setQueuedTimestamp(Timestamps.fromMillis(System.currentTimeMillis()))
+              .setQueuedTimestamp(Timestamps.now())
               .build();
       ExecuteOperationMetadata metadata =
           ExecuteOperationMetadata.newBuilder()

--- a/src/main/java/build/buildfarm/server/services/ExecutionService.java
+++ b/src/main/java/build/buildfarm/server/services/ExecutionService.java
@@ -51,7 +51,7 @@ import lombok.extern.java.Log;
 @Log
 public class ExecutionService extends ExecutionGrpc.ExecutionImplBase {
   private final Instance instance;
-  private final long keepaliveAfter;
+  private final long keepaliveAfter; /* Seconds */
   private final ScheduledExecutorService keepaliveScheduler;
   private final MetricsPublisher metricsPublisher;
 

--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -365,7 +365,7 @@ class Executor {
         .metadata
         .getExecuteOperationMetadataBuilder()
         .getPartialExecutionMetadataBuilder()
-        .setExecutionCompletedTimestamp(Timestamps.fromMillis(System.currentTimeMillis()));
+        .setExecutionCompletedTimestamp(Timestamps.now());
     putOperation(/* ignoreFailure= */ true);
 
     log.log(

--- a/src/main/java/build/buildfarm/worker/InputFetcher.java
+++ b/src/main/java/build/buildfarm/worker/InputFetcher.java
@@ -235,8 +235,7 @@ public class InputFetcher implements Runnable {
         log.log(Level.SEVERE, format("error creating exec dir for %s", executionName), e);
       }
       // populate the inputFetch complete to know how long it took before error
-      executedAction.setInputFetchCompletedTimestamp(
-          Timestamps.fromMillis(System.currentTimeMillis()));
+      executedAction.setInputFetchCompletedTimestamp(Timestamps.now());
       failOperation(executedAction.build(), status.build());
       return 0;
     }
@@ -253,8 +252,7 @@ public class InputFetcher implements Runnable {
             .addAllArguments(Iterables.skip(queuedOperation.getCommand().getArgumentsList(), 1))
             .build();
 
-    executedAction.setInputFetchCompletedTimestamp(
-        Timestamps.fromMillis(System.currentTimeMillis()));
+    executedAction.setInputFetchCompletedTimestamp(Timestamps.now());
     putOperation();
 
     // we are now responsible for destroying the exec dir if anything goes wrong

--- a/src/main/java/build/buildfarm/worker/ResultReporter.java
+++ b/src/main/java/build/buildfarm/worker/ResultReporter.java
@@ -139,7 +139,7 @@ class ResultReporter implements Runnable {
             .metadata
             .getExecuteOperationMetadataBuilder()
             .getPartialExecutionMetadataBuilder()
-            .setOutputUploadStartTimestamp(Timestamps.fromMillis(System.currentTimeMillis()));
+            .setOutputUploadStartTimestamp(Timestamps.now());
     putOperation(executionContext);
 
     boolean blacklist = false;

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -76,6 +76,7 @@ import com.google.common.collect.SetMultimap;
 import com.google.longrunning.Operation;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Duration;
+import com.google.protobuf.util.Durations;
 import com.google.rpc.PreconditionFailure;
 import io.grpc.Deadline;
 import io.grpc.Status;
@@ -422,12 +423,12 @@ class ShardWorkerContext implements WorkerContext {
 
   @Override
   public boolean hasDefaultActionTimeout() {
-    return defaultActionTimeout.getSeconds() > 0 || defaultActionTimeout.getNanos() > 0;
+    return Durations.isPositive(defaultActionTimeout);
   }
 
   @Override
   public boolean hasMaximumActionTimeout() {
-    return maximumActionTimeout.getSeconds() > 0 || maximumActionTimeout.getNanos() > 0;
+    return Durations.isPositive(maximumActionTimeout);
   }
 
   @Override


### PR DESCRIPTION
Some time clean-ups:
- prefer Durations.toNanos() and similar
- prefer Timestamp.now() instead of Timestamps.fromMillis(System.currentTimeMillis())
- leave some comments for units of variables