### PR TITLE
chore(deps): bump rules_oci to 2.0.1

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,5 @@
 load("@buildifier_prebuilt//:rules.bzl", "buildifier")
-load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index", "oci_push", "oci_tarball")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index", "oci_load", "oci_push")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
 load("//:jvm_flags.bzl", "server_jvm_flags", "worker_jvm_flags")
@@ -238,7 +238,7 @@ oci_image(
 ######
 [
     [
-        oci_tarball(
+        oci_load(
             name = "tarball_%s_%s" % (image, arch),
             image = ":buildfarm-%s_linux_%s" % (image, arch),
             repo_tags = ["buildfarm-%s:%s" % (image, arch)],

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,7 +19,7 @@ bazel_dep(name = "rules_go", version = "0.50.1")
 bazel_dep(name = "rules_java", version = "7.12.0")
 bazel_dep(name = "rules_jvm_external", version = "6.4")
 bazel_dep(name = "rules_license", version = "1.0.0")
-bazel_dep(name = "rules_oci", version = "1.7.4")
+bazel_dep(name = "rules_oci", version = "2.0.1")
 bazel_dep(name = "rules_pkg", version = "1.0.1")
 
 # Test dependencies


### PR DESCRIPTION
2.0.0 release notes: https://github.com/bazel-contrib/rules_oci/releases/tag/v2.0.0