### PR TITLE
ci: add multi-arch Ubunutu Noble

### DIFF
--- a/.github/workflows/buildfarm-worker-base-build-and-deploy.yml
+++ b/.github/workflows/buildfarm-worker-base-build-and-deploy.yml
@@ -54,7 +54,7 @@ jobs:
           tags: bazelbuild/buildfarm-worker-base:lunar
 
       - name: Build Multi-arch Noble Docker image
-        # AKA Ubuntu 23
+        # AKA Ubuntu 24
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
           context: .

--- a/.github/workflows/buildfarm-worker-base-build-and-deploy.yml
+++ b/.github/workflows/buildfarm-worker-base-build-and-deploy.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - ci/base-worker-image/jammy/Dockerfile
       - ci/base-worker-image/lunar/Dockerfile
+      - ci/base-worker-image/noble/Dockerfile
 permissions:
   contents: read
 
@@ -19,13 +20,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        # QEMU needed for the ARM variant.
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        # Docker Buildx needed for the ARM variant.
+
       - name: Login to Bazelbuild Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.BAZELBUILD_DOCKERHUB_USERNAME }}
           password: ${{ secrets.BAZELBUILD_DOCKERHUB_TOKEN }}
 
+
       - name: Build Jammy Docker image
+        # AKA Ubuntu 22
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
           context: .
@@ -33,10 +44,21 @@ jobs:
           push: true
           tags: bazelbuild/buildfarm-worker-base:jammy
 
-      - name: Build Mantic Docker image
+      - name: Build Lunar Docker image
+        # AKA Ubuntu 23
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
           context: .
           file: ./ci/base-worker-image/lunar/Dockerfile
           push: true
           tags: bazelbuild/buildfarm-worker-base:lunar
+
+      - name: Build Multi-arch Noble Docker image
+        # AKA Ubuntu 23
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64/v8
+          file: ./ci/base-worker-image/noble/Dockerfile
+          push: true
+          tags: bazelbuild/buildfarm-worker-base:noble

--- a/ci/base-worker-image/noble/Dockerfile
+++ b/ci/base-worker-image/noble/Dockerfile
@@ -1,0 +1,6 @@
+# A minimal container for building a base worker image.
+# Buildfarm public releases are build using this image as a starting point.
+FROM ubuntu:24.04
+
+RUN apt-get update
+RUN apt-get -y install openjdk-21-jdk build-essential libfuse2 cgroup-tools


### PR DESCRIPTION
Adding linux/arm64/v8 variants for Ubunutu 24 (Noble) worker images.

The GitHub Actions changes were based on https://docs.docker.com/build/ci/github-actions/multi-platform/ , QEMU and Docker Buildx needed for the ARM variant.