### PR TITLE
chore: configure renovate again

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,31 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
+    ":approveMajorUpdates",
+    ":label(dependencies)",
     ":semanticCommitType(chore)",
-    ":label(dependencies)"
+    "docker:pinDigests",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "prConcurrentLimit": 10,
+  "packageRules": [
+    {
+      "groupName": "Bazel",
+      "matchManagers": ["bazel"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": "true"
+    },
+    {
+      "groupName": "tini",
+      "description": "tini x86_64 and arm64v8",
+      "matchManagers": ["http_file"],
+      "matchPackageNames": ["tini*"]
+    },
+    {
+      "groupName": "rules_proto",
+      "description": "disable rules_proto as it's transitive and Buildfarm does not use it",
+      "matchPackageNames": ["rules_proto"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
- only 10 open PRs (so we don't saturate BuildKite)
- do not open PRs for major dep bumps - wait for someone to ask via Dependency Dashboard
- pin docker digests and github action digests
- auto-merge minor/patch `.bazelversion` bumps WITH HUMAN APPROVAL TOO.