### PR TITLE
refactor(cas): prefer records over POJOs

### DIFF
--- a/src/main/java/build/buildfarm/worker/CFCLinkExecFileSystem.java
+++ b/src/main/java/build/buildfarm/worker/CFCLinkExecFileSystem.java
@@ -139,7 +139,7 @@ public class CFCLinkExecFileSystem extends CFCExecFileSystem {
     return transformAsync(
         fileCache.putDirectory(digest, directoriesIndex, fetchService),
         pathResult -> {
-          Path path = pathResult.getPath();
+          Path path = pathResult.path();
           if (pathResult.isMissed()) {
             log.finer(
                 String.format(

--- a/src/test/java/build/buildfarm/cas/cfc/CASFileCacheTest.java
+++ b/src/test/java/build/buildfarm/cas/cfc/CASFileCacheTest.java
@@ -256,7 +256,7 @@ class CASFileCacheTest {
     Path dirPath =
         getInterruptiblyOrIOException(
                 fileCache.putDirectory(dirDigest, directoriesIndex, putService))
-            .getPath();
+            .path();
     assertThat(Files.isDirectory(dirPath)).isTrue();
     assertThat(Files.exists(dirPath.resolve("file"))).isTrue();
     assertThat(Files.isDirectory(dirPath.resolve("subdir"))).isTrue();
@@ -325,11 +325,11 @@ class CASFileCacheTest {
     StartupCacheResults results = fileCache.start(false);
 
     // check the startuo results to ensure no files were processed
-    assertThat(results.load.loadSkipped).isFalse();
-    assertThat(results.load.scan.computeDirs.size()).isEqualTo(0);
-    assertThat(results.load.scan.deleteFiles.size()).isEqualTo(0);
-    assertThat(results.load.scan.fileKeys.size()).isEqualTo(0);
-    assertThat(results.load.invalidDirectories.size()).isEqualTo(0);
+    assertThat(results.load().loadSkipped()).isFalse();
+    assertThat(results.load().scan().computeDirs().size()).isEqualTo(0);
+    assertThat(results.load().scan().deleteFiles().size()).isEqualTo(0);
+    assertThat(results.load().scan().fileKeys().size()).isEqualTo(0);
+    assertThat(results.load().invalidDirectories().size()).isEqualTo(0);
   }
 
   @Test
@@ -344,11 +344,11 @@ class CASFileCacheTest {
     StartupCacheResults results = fileCache.start(false);
 
     // check the startup results to ensure no files were processed
-    assertThat(results.load.loadSkipped).isFalse();
-    assertThat(results.load.scan.computeDirs.size()).isEqualTo(0);
-    assertThat(results.load.scan.deleteFiles.size()).isEqualTo(1);
-    assertThat(results.load.scan.fileKeys.size()).isEqualTo(0);
-    assertThat(results.load.invalidDirectories.size()).isEqualTo(0);
+    assertThat(results.load().loadSkipped()).isFalse();
+    assertThat(results.load().scan().computeDirs().size()).isEqualTo(0);
+    assertThat(results.load().scan().deleteFiles().size()).isEqualTo(1);
+    assertThat(results.load().scan().fileKeys().size()).isEqualTo(0);
+    assertThat(results.load().invalidDirectories().size()).isEqualTo(0);
   }
 
   @Test
@@ -366,11 +366,11 @@ class CASFileCacheTest {
     StartupCacheResults results = fileCache.start(false);
 
     // check the startup results to ensure our two files were processed
-    assertThat(results.load.loadSkipped).isFalse();
-    assertThat(results.load.scan.computeDirs.size()).isEqualTo(0);
-    assertThat(results.load.scan.deleteFiles.size()).isEqualTo(0);
-    assertThat(results.load.scan.fileKeys.size()).isEqualTo(2);
-    assertThat(results.load.invalidDirectories.size()).isEqualTo(0);
+    assertThat(results.load().loadSkipped()).isFalse();
+    assertThat(results.load().scan().computeDirs().size()).isEqualTo(0);
+    assertThat(results.load().scan().deleteFiles().size()).isEqualTo(0);
+    assertThat(results.load().scan().fileKeys().size()).isEqualTo(2);
+    assertThat(results.load().invalidDirectories().size()).isEqualTo(0);
 
     // explicitly not providing blob via blobs, this would throw if fetched from factory
     //
@@ -394,11 +394,11 @@ class CASFileCacheTest {
     StartupCacheResults results = fileCache.start(/* skipLoad= */ true);
 
     // check the startup results to ensure our two files were processed
-    assertThat(results.load.loadSkipped).isTrue();
-    assertThat(results.load.scan.computeDirs.size()).isEqualTo(0);
-    assertThat(results.load.scan.deleteFiles.size()).isEqualTo(0);
-    assertThat(results.load.scan.fileKeys.size()).isEqualTo(0);
-    assertThat(results.load.invalidDirectories.size()).isEqualTo(0);
+    assertThat(results.load().loadSkipped()).isTrue();
+    assertThat(results.load().scan().computeDirs().size()).isEqualTo(0);
+    assertThat(results.load().scan().deleteFiles().size()).isEqualTo(0);
+    assertThat(results.load().scan().fileKeys().size()).isEqualTo(0);
+    assertThat(results.load().invalidDirectories().size()).isEqualTo(0);
   }
 
   @Test


### PR DESCRIPTION
Records implement `equals()` and `hashCode()` and are immutable once created.