### PR TITLE
chore(renovate): maven dependencies require approval always

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
     "docker:pinDigests",
     "helpers:pinGitHubActionDigests"
   ],
-  "prConcurrentLimit": 10,
+  "prConcurrentLimit": 2,
   "packageRules": [
     {
       "groupName": "Bazel",

--- a/renovate.json
+++ b/renovate.json
@@ -26,6 +26,13 @@
       "description": "disable rules_proto as it's transitive and Buildfarm does not use it",
       "matchPackageNames": ["rules_proto"],
       "enabled": false
+    },
+    {
+      "groupName": "Maven deps",
+      "description": "Maven dependencies need to be pinned by 'REPIN=1 bazelisk run @maven//:pin && git add maven_install.json && git commit' to pass CI, then they can be auto-merged after approval",
+      "matchManagers": ["maven"],
+      "dependencyDashboardApproval": true,
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
also, reduce the rate limit to two concurrent PRs from Renovate.