### PR TITLE
build(bazel): update java_proto_library

### DIFF
--- a/persistentworkers/src/main/protobuf/BUILD
+++ b/persistentworkers/src/main/protobuf/BUILD
@@ -1,6 +1,6 @@
 load("@bazel_tools//tools/build_rules:utilities.bzl", "java_library_srcs")
+load("@protobuf//bazel:java_proto_library.bzl", "java_proto_library")
 load("@protobuf//bazel:proto_library.bzl", "proto_library")
-load("@rules_java//java:defs.bzl", "java_proto_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/main/java/build/buildfarm/common/resources/BUILD
+++ b/src/main/java/build/buildfarm/common/resources/BUILD
@@ -1,5 +1,5 @@
+load("@protobuf//bazel:java_proto_library.bzl", "java_proto_library")
 load("@protobuf//bazel:proto_library.bzl", "proto_library")
-load("@rules_java//java:defs.bzl", "java_proto_library")
 
 package(default_visibility = ["//visibility:public"])
 


### PR DESCRIPTION
The one from `@rules_java` is deprecated.