### PR TITLE
feat: add runtimeClassName field for scheduler and worker

### DIFF
--- a/kubernetes/helm-charts/buildfarm/templates/server/deployment.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/server/deployment.yaml
@@ -64,6 +64,9 @@ spec:
             {{- with .Values.server.extraVolumeMounts }}
             {{- tpl (toYaml .) $ | nindent 12 -}}
             {{- end }}
+      {{- with .Values.server.runtimeClassName }}
+      runtimeClassName: {{ tpl . $ }}
+      {{- end }}
       {{- with .Values.server.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/kubernetes/helm-charts/buildfarm/templates/shard-worker/statefulsets.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/shard-worker/statefulsets.yaml
@@ -80,6 +80,9 @@ spec:
             {{- with .Values.shardWorker.extraVolumeMounts }}
             {{- tpl (toYaml .) $ | nindent 12 -}}
             {{- end }}
+      {{- with .Values.shardWorker.runtimeClassName }}
+      runtimeClassName: {{ tpl . $ }}
+      {{- end }}
 
       {{- with .Values.shardWorker.nodeSelector }}
       nodeSelector:

--- a/kubernetes/helm-charts/buildfarm/values.yaml
+++ b/kubernetes/helm-charts/buildfarm/values.yaml
@@ -66,6 +66,7 @@ server:
     #    hosts:
     #      - chart-example.local
 
+  runtimeClassName: ""
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -145,6 +146,7 @@ shardWorker:
     type: ClusterIP
     port: 8982
 
+  #runtimeClassName: ""
   #nodeSelector: {}
   #tolerations: []
   #affinity: {}


### PR DESCRIPTION
### What

SSIA

### Why

- Enable to set `nodeSelector` or `tolerations` via RuntimeClass ([ref](https://kubernetes.io/docs/concepts/containers/runtime-class/#scheduling))

### Checklist

- [x] Deployed buildfarm family with `{server, shardWorker}.runtimeClassName`

```
helm install buildfarm ./kubernetes/helm-charts/buildfarm --set shardWorker.runtimeClassName=something-runtime --set server.runtimeClassName=something-runtime
```