### PR TITLE
Specify ExecutionCapabilities digestFunction from config

### DIFF
--- a/src/main/java/build/buildfarm/instance/server/BUILD
+++ b/src/main/java/build/buildfarm/instance/server/BUILD
@@ -7,6 +7,7 @@ java_library(
         "//src/main/java/build/buildfarm/actioncache",
         "//src/main/java/build/buildfarm/cas",
         "//src/main/java/build/buildfarm/common",
+        "//src/main/java/build/buildfarm/common/config",
         "//src/main/java/build/buildfarm/common/resources",
         "//src/main/java/build/buildfarm/common/resources:resource_java_proto",
         "//src/main/java/build/buildfarm/instance",

--- a/src/main/java/build/buildfarm/instance/server/NodeInstance.java
+++ b/src/main/java/build/buildfarm/instance/server/NodeInstance.java
@@ -75,6 +75,7 @@ import build.buildfarm.common.Size;
 import build.buildfarm.common.TokenizableIterator;
 import build.buildfarm.common.TreeIterator.DirectoryEntry;
 import build.buildfarm.common.Write;
+import build.buildfarm.common.config.BuildfarmConfigs;
 import build.buildfarm.common.function.IOSupplier;
 import build.buildfarm.common.net.URL;
 import build.buildfarm.common.resources.BlobInformation;
@@ -149,6 +150,8 @@ import org.apache.http.auth.Credentials;
 
 @Log
 public abstract class NodeInstance extends InstanceBase {
+  private static BuildfarmConfigs configs = BuildfarmConfigs.getInstance();
+
   protected final ContentAddressableStorage contentAddressableStorage;
   protected final ActionCache actionCache;
   protected final OperationsMap outstandingOperations;
@@ -1728,7 +1731,7 @@ public abstract class NodeInstance extends InstanceBase {
 
   protected ExecutionCapabilities getExecutionCapabilities() {
     return ExecutionCapabilities.newBuilder()
-        .setDigestFunction(DigestFunction.Value.BLAKE3)
+        .setDigestFunction(configs.getDigestFunction().getDigestFunction())
         .addAllDigestFunctions(getDigestFunctions())
         .setExecEnabled(true)
         .setExecutionPriorityCapabilities(


### PR DESCRIPTION
Legacy clients, including remote-apis-sdk, only observe this field to determine whether a digest function on the client is compatible with a server. Allow deployments to specify the value returned here to be compatible with these clients.