### PR TITLE
Restore previous external/* default linked dir behavior

### DIFF
--- a/examples/config.minimal.yml
+++ b/examples/config.minimal.yml
@@ -9,3 +9,5 @@ worker:
   publicName: localhost:8981
   dequeueMatchSettings:
     allowUnmatched: true
+  linkedInputDirectories:
+  - (?!external/)[^/]+


### PR DESCRIPTION
Fix matching string for external to match original defaults tuned for bazel.
All toplevel directories are linkable, except for external, under which all first-child directories are linkable.