### PR TITLE
Prevent match hangs during worker shutdown

### DIFF
--- a/src/main/java/build/buildfarm/worker/MatchListener.java
+++ b/src/main/java/build/buildfarm/worker/MatchListener.java
@@ -20,7 +20,8 @@ import javax.annotation.Nullable;
 
 public interface MatchListener {
   // start/end pair called for each wait period
-  void onWaitStart();
+  // if this returns false, the wait does not begin, and onEntry will be called with 'null'
+  boolean onWaitStart();
 
   void onWaitEnd();
 

--- a/src/main/java/build/buildfarm/worker/MatchStage.java
+++ b/src/main/java/build/buildfarm/worker/MatchStage.java
@@ -64,8 +64,9 @@ public class MatchStage extends PipelineStage {
     }
 
     @Override
-    public void onWaitStart() {
+    public boolean onWaitStart() {
       waitStart = stopwatch.elapsed(MICROSECONDS);
+      return !inGracefulShutdown;
     }
 
     @Override
@@ -79,6 +80,10 @@ public class MatchStage extends PipelineStage {
     @Override
     public boolean onEntry(@Nullable QueueEntry queueEntry, Claim claim)
         throws InterruptedException {
+      if (inGracefulShutdown) {
+        throw new InterruptedException();
+      }
+
       if (queueEntry == null) {
         return false;
       }

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -291,7 +291,10 @@ class ShardWorkerContext implements WorkerContext {
 
   private @Nullable QueueEntry takeEntryOffOperationQueue(MatchListener listener)
       throws IOException, InterruptedException {
-    listener.onWaitStart();
+    if (!listener.onWaitStart()) {
+      // match listener can signal completion here
+      return null;
+    }
     QueueEntry queueEntry = null;
     try {
       queueEntry =
@@ -327,8 +330,8 @@ class ShardWorkerContext implements WorkerContext {
           }
 
           @Override
-          public void onWaitStart() {
-            listener.onWaitStart();
+          public boolean onWaitStart() {
+            return listener.onWaitStart();
           }
 
           @Override

--- a/src/test/java/build/buildfarm/worker/shard/ShardWorkerContextTest.java
+++ b/src/test/java/build/buildfarm/worker/shard/ShardWorkerContextTest.java
@@ -135,8 +135,10 @@ public class ShardWorkerContextTest {
         .thenReturn(queueEntry)
         .thenReturn(null); // provide a match completion in failure case
     MatchListener listener = mock(MatchListener.class);
+    when(listener.onWaitStart()).thenReturn(true);
     context.match(listener);
     verify(listener, times(1)).onEntry(eq(queueEntry), any(Claim.class));
+    verify(listener, times(1)).onWaitStart();
   }
 
   @Test
@@ -172,8 +174,10 @@ public class ShardWorkerContextTest {
         .thenReturn(queueEntry)
         .thenReturn(null); // provide a match completion in failure case
     MatchListener listener = mock(MatchListener.class);
+    when(listener.onWaitStart()).thenReturn(true);
     context.match(listener);
     verify(listener, times(1)).onEntry(eq(queueEntry), any(Claim.class));
+    verify(listener, times(1)).onWaitStart();
   }
 
   @Test


### PR DESCRIPTION
During a dispatch/reject cycle, workers can become unresponsive due to a
lack of concern for thread interrupt status. Ensure that a shutdown
initiates a discard of the currently outstanding match behavior, and the
matcher can indicate as much via the MatchListener.