### PR TITLE
Only stop WorkerStub instances on idle

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/RemoteInputStreamFactory.java
+++ b/src/main/java/build/buildfarm/instance/shard/RemoteInputStreamFactory.java
@@ -30,6 +30,7 @@ import build.buildfarm.common.DigestUtil;
 import build.buildfarm.common.InputStreamFactory;
 import build.buildfarm.instance.Instance;
 import build.buildfarm.instance.shard.ServerInstance.WorkersCallback;
+import build.buildfarm.instance.stub.StubInstance;
 import build.buildfarm.v1test.Digest;
 import com.google.common.base.Throwables;
 import com.google.common.cache.LoadingCache;
@@ -64,13 +65,13 @@ public class RemoteInputStreamFactory implements InputStreamFactory {
   private final @Nullable String publicName;
   private final Backplane backplane;
   private final Random rand;
-  private final LoadingCache<String, Instance> workerStubs;
+  private final LoadingCache<String, StubInstance> workerStubs;
   private final UnavailableConsumer onUnavailable;
 
   RemoteInputStreamFactory(
       Backplane backplane,
       Random rand,
-      LoadingCache<String, Instance> workerStubs,
+      LoadingCache<String, StubInstance> workerStubs,
       UnavailableConsumer onUnavailable) {
     this(/* publicName= */ null, backplane, rand, workerStubs, onUnavailable);
   }
@@ -80,7 +81,7 @@ public class RemoteInputStreamFactory implements InputStreamFactory {
       String publicName,
       Backplane backplane,
       Random rand,
-      LoadingCache<String, Instance> workerStubs,
+      LoadingCache<String, StubInstance> workerStubs,
       UnavailableConsumer onUnavailable) {
     this.publicName = publicName;
     this.backplane = backplane;
@@ -91,7 +92,9 @@ public class RemoteInputStreamFactory implements InputStreamFactory {
 
   private Instance workerStub(String worker) {
     try {
-      return workerStubs.get(worker);
+      StubInstance stubInstance = workerStubs.get(worker);
+      stubInstance.setOnStopped(() -> workerStubs.invalidate(worker));
+      return stubInstance;
     } catch (ExecutionException e) {
       log.log(Level.SEVERE, String.format("error getting worker stub for %s", worker), e);
       throw new IllegalStateException("stub instance creation must not fail");

--- a/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
@@ -89,6 +89,7 @@ import build.buildfarm.common.redis.RedisHashtags;
 import build.buildfarm.instance.Instance;
 import build.buildfarm.instance.server.Filter;
 import build.buildfarm.instance.server.NodeInstance;
+import build.buildfarm.instance.stub.StubInstance;
 import build.buildfarm.v1test.BackplaneStatus;
 import build.buildfarm.v1test.DispatchedOperation;
 import build.buildfarm.v1test.ExecuteEntry;
@@ -246,7 +247,7 @@ public class ServerInstance extends NodeInstance {
   private final Backplane backplane;
   private final ActionCache actionCache;
   private final RemoteInputStreamFactory remoteInputStreamFactory;
-  private final com.google.common.cache.LoadingCache<String, Instance> workerStubs;
+  private final com.google.common.cache.LoadingCache<String, StubInstance> workerStubs;
   private final Thread dispatchedMonitor;
   private final Duration maxActionTimeout;
   private AsyncCache<build.buildfarm.v1test.Digest, Directory> directoryCache;
@@ -361,7 +362,7 @@ public class ServerInstance extends NodeInstance {
       Duration maxActionTimeout,
       boolean useDenyList,
       Runnable onStop,
-      LoadingCache<String, Instance> workerStubs,
+      LoadingCache<String, StubInstance> workerStubs,
       ListeningExecutorService actionCacheFetchService,
       boolean ensureOutputsPresent) {
     super(
@@ -1391,7 +1392,9 @@ public class ServerInstance extends NodeInstance {
 
   private Instance workerStub(String worker) {
     try {
-      return workerStubs.get(worker);
+      StubInstance stubInstance = workerStubs.get(worker);
+      stubInstance.setOnStopped(() -> workerStubs.invalidate(worker));
+      return stubInstance;
     } catch (ExecutionException e) {
       log.log(Level.SEVERE, "error getting worker stub for " + worker, e);
       throw new IllegalStateException("stub instance creation must not fail");

--- a/src/main/java/build/buildfarm/instance/stub/StubInstance.java
+++ b/src/main/java/build/buildfarm/instance/stub/StubInstance.java
@@ -166,6 +166,10 @@ public class StubInstance extends InstanceBase {
   private final Retrier retrier;
   private final @Nullable ListeningScheduledExecutorService retryService;
   private boolean isStopped = false;
+
+  @GuardedBy("this")
+  private Runnable onStopped;
+
   private final long maxBatchUpdateBlobsSize = Size.mbToBytes(3);
 
   @VisibleForTesting long maxRequestSize = Size.mbToBytes(4);
@@ -213,6 +217,16 @@ public class StubInstance extends InstanceBase {
 
   public Channel getChannel() {
     return channel;
+  }
+
+  public void setOnStopped(Runnable onStopped) {
+    if (isStopped) {
+      onStopped.run();
+    } else {
+      synchronized (this) {
+        this.onStopped = onStopped;
+      }
+    }
   }
 
   // no deadline for this
@@ -375,6 +389,14 @@ public class StubInstance extends InstanceBase {
     if (retryService != null && !shutdownAndAwaitTermination(retryService, 10, TimeUnit.SECONDS)) {
       log.log(Level.SEVERE, format("Could not shut down retry service for %s", identifier));
     }
+    Runnable onStopped = () -> {};
+    synchronized (this) {
+      if (this.onStopped != null) {
+        onStopped = this.onStopped;
+        this.onStopped = null;
+      }
+    }
+    onStopped.run();
   }
 
   private void throwIfStopped() {

--- a/src/main/java/build/buildfarm/worker/shard/BUILD
+++ b/src/main/java/build/buildfarm/worker/shard/BUILD
@@ -14,6 +14,7 @@ java_library(
         "//src/main/java/build/buildfarm/instance",
         "//src/main/java/build/buildfarm/instance/server",
         "//src/main/java/build/buildfarm/instance/shard",
+        "//src/main/java/build/buildfarm/instance/stub",
         "//src/main/java/build/buildfarm/metrics/prometheus",
         "//src/main/java/build/buildfarm/worker",
         "//src/main/java/build/buildfarm/worker/cgroup",

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -50,6 +50,7 @@ import build.buildfarm.instance.Instance;
 import build.buildfarm.instance.shard.RedisShardBackplane;
 import build.buildfarm.instance.shard.RemoteInputStreamFactory;
 import build.buildfarm.instance.shard.WorkerStubs;
+import build.buildfarm.instance.stub.StubInstance;
 import build.buildfarm.metrics.prometheus.PrometheusPublisher;
 import build.buildfarm.v1test.Digest;
 import build.buildfarm.v1test.ShardWorker;
@@ -143,7 +144,7 @@ public final class Worker extends LoggingMain {
   private ExecFileSystem execFileSystem;
   private Pipeline pipeline;
   private Backplane backplane;
-  private LoadingCache<String, Instance> workerStubs;
+  private LoadingCache<String, StubInstance> workerStubs;
   private AtomicBoolean released = new AtomicBoolean(true);
 
   /**

--- a/src/test/java/build/buildfarm/instance/shard/BUILD
+++ b/src/test/java/build/buildfarm/instance/shard/BUILD
@@ -140,6 +140,7 @@ java_test(
         "//src/main/java/build/buildfarm/instance",
         "//src/main/java/build/buildfarm/instance/server",
         "//src/main/java/build/buildfarm/instance/shard",
+        "//src/main/java/build/buildfarm/instance/stub",
         "//src/main/protobuf/build/buildfarm/v1test:buildfarm_java_proto",
         "//src/test/java/build/buildfarm:test_runner",
         "@googleapis//google/longrunning:longrunning_java_proto",

--- a/src/test/java/build/buildfarm/instance/shard/ServerInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/ServerInstanceTest.java
@@ -72,7 +72,7 @@ import build.buildfarm.common.Poller;
 import build.buildfarm.common.Watcher;
 import build.buildfarm.common.Write.NullWrite;
 import build.buildfarm.common.config.BuildfarmConfigs;
-import build.buildfarm.instance.Instance;
+import build.buildfarm.instance.stub.StubInstance;
 import build.buildfarm.v1test.ExecuteEntry;
 import build.buildfarm.v1test.QueueEntry;
 import build.buildfarm.v1test.QueuedOperation;
@@ -142,9 +142,9 @@ public class ServerInstanceTest {
 
   @Mock private Runnable mockOnStop;
 
-  @Mock private CacheLoader<String, Instance> mockInstanceLoader;
+  @Mock private CacheLoader<String, StubInstance> mockInstanceLoader;
 
-  @Mock Instance mockWorkerInstance;
+  @Mock StubInstance mockWorkerInstance;
 
   @Before
   public void setUp() throws IOException, InterruptedException {


### PR DESCRIPTION
Monitor the ConnectivityState for WorkerStubs' channels. When all channels go idle, the instance will be stopped. This will prevent rejected executions when a retry executor has been stopped, while still bounding the instance lifetime, and permitting expiration in the worker stub cache to ensure limited channel use.

All callers are required to register onStopped callbacks which invalidate against the Cache - a clear solution for a value-state-change- initiated action against the LoadingCache object is not obvious without hooking the response. Could be reorganized to another static method in WorkerStubs, or turning WorkerStubs instance into a subclass of cache.