### PR TITLE
Set a keepalive ping time for Buildfarm channels

### DIFF
--- a/src/main/java/build/buildfarm/common/grpc/Channels.java
+++ b/src/main/java/build/buildfarm/common/grpc/Channels.java
@@ -14,6 +14,8 @@
 
 package build.buildfarm.common.grpc;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import io.grpc.ManagedChannel;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
@@ -33,8 +35,10 @@ public final class Channels {
       target = target.substring(GRPC_URL_PREFIX.length());
       negotiationType = NegotiationType.PLAINTEXT;
     }
-    NettyChannelBuilder builder =
-        NettyChannelBuilder.forTarget(target).negotiationType(negotiationType);
-    return builder.build();
+    return NettyChannelBuilder.forTarget(target)
+        .negotiationType(negotiationType)
+        .keepAliveTime(300, SECONDS)
+        .keepAliveTimeout(10, SECONDS)
+        .build();
   }
 }


### PR DESCRIPTION
Sane initial default. Pings will be sent out on 5m intervals, and any worker (only possible recipient) that does not respond in time will have their connection reset.