### PR TITLE
refactor: prefer Path.of() instead of Paths.get()

### DIFF
--- a/persistentworkers/src/main/java/persistent/common/util/Args.java
+++ b/persistentworkers/src/main/java/persistent/common/util/Args.java
@@ -2,7 +2,7 @@ package persistent.common.util;
 
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -31,6 +31,6 @@ public class Args {
   public static List<String> readAllLines(String fileArg) throws IOException {
     String file = isArgsFile(fileArg) ? fileArg.substring(1) : fileArg;
 
-    return Files.readAllLines(Paths.get(file));
+    return Files.readAllLines(Path.of(file));
   }
 }

--- a/persistentworkers/src/test/java/persistent/testutil/ProcessUtils.java
+++ b/persistentworkers/src/test/java/persistent/testutil/ProcessUtils.java
@@ -6,7 +6,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import org.apache.commons.io.IOUtils;
 import persistent.bazel.client.PersistentWorker;
 import persistent.common.processes.JavaProcessWrapper;
@@ -20,7 +19,7 @@ public class ProcessUtils {
       throws IOException {
     JavaProcessWrapper jpw =
         new JavaProcessWrapper(
-            Paths.get("."),
+            Path.of("."),
             classpath,
             className,
             new String[] {PersistentWorker.PERSISTENT_WORKER_FLAG});

--- a/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
+++ b/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
@@ -12,7 +12,6 @@ import java.io.InputStream;
 import java.net.InetAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -132,7 +131,7 @@ public final class BuildfarmConfigs {
   private static Path getConfigurationPath(OptionsParser parser) throws ConfigurationException {
     // source config from env variable
     if (!Strings.isNullOrEmpty(System.getenv("CONFIG_PATH"))) {
-      return Paths.get(System.getenv("CONFIG_PATH"));
+      return Path.of(System.getenv("CONFIG_PATH"));
     }
 
     // source config from cli
@@ -143,7 +142,7 @@ public final class BuildfarmConfigs {
       throw new ConfigurationException("A valid path to a configuration file must be provided.");
     }
 
-    return Paths.get(residue.getFirst());
+    return Path.of(residue.getFirst());
   }
 
   private static void adjustServerConfigs(BuildfarmConfigs configs) {
@@ -310,7 +309,7 @@ public final class BuildfarmConfigs {
         (tools, features) ->
             tools.forEach(
                 (tool) -> {
-                  if (Files.notExists(Paths.get(tool))) {
+                  if (Files.notExists(Path.of(tool))) {
                     String message =
                         String.format(
                             "the execution wrapper %s is missing and therefore the following"

--- a/src/main/java/build/buildfarm/common/config/Worker.java
+++ b/src/main/java/build/buildfarm/common/config/Worker.java
@@ -4,7 +4,6 @@ import build.buildfarm.v1test.WorkerType;
 import com.google.common.base.Strings;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -71,13 +70,13 @@ public class Worker {
     verifyRootConfiguration();
     addRootIfMissing();
     verifyRootLocation();
-    return Paths.get(root);
+    return Path.of(root);
   }
 
   private void addRootIfMissing() throws ConfigurationException {
     try {
-      if (!Files.isDirectory(Paths.get(root))) {
-        Files.createDirectories(Paths.get(root));
+      if (!Files.isDirectory(Path.of(root))) {
+        Files.createDirectories(Path.of(root));
       }
     } catch (Exception e) {
       throw new ConfigurationException(e.toString());
@@ -93,7 +92,7 @@ public class Worker {
 
   private void verifyRootLocation() throws ConfigurationException {
     // Configuration error if root does not exist.
-    if (!Files.isDirectory(Paths.get(root))) {
+    if (!Files.isDirectory(Path.of(root))) {
       throw new ConfigurationException("root [" + root + "] is not directory");
     }
   }

--- a/src/main/java/build/buildfarm/tools/Cat.java
+++ b/src/main/java/build/buildfarm/tools/Cat.java
@@ -77,7 +77,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -445,7 +444,7 @@ class Cat {
     messages.add(queuedOperation.getAction());
     messages.add(queuedOperation.getCommand());
     messages.addAll(queuedOperation.getTree().getDirectoriesMap().values());
-    Path blobs = Paths.get("blobs");
+    Path blobs = Path.of("blobs");
     for (Message message : messages.build()) {
       Digest digest = digestUtil.compute(message);
       try (OutputStream out =

--- a/src/main/java/build/buildfarm/tools/Executor.java
+++ b/src/main/java/build/buildfarm/tools/Executor.java
@@ -62,7 +62,6 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.FileStore;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Scanner;
 import java.util.UUID;
@@ -427,7 +426,7 @@ class Executor {
 
     if (blobsDir != null) {
       System.out.println("Loading blobs into cas");
-      loadFilesIntoCAS(instanceName, channel, Paths.get(blobsDir));
+      loadFilesIntoCAS(instanceName, channel, Path.of(blobsDir));
     }
 
     ExecutionStub execStub = ExecutionGrpc.newStub(channel);

--- a/src/main/java/build/buildfarm/tools/Extract.java
+++ b/src/main/java/build/buildfarm/tools/Extract.java
@@ -49,7 +49,6 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.Scanner;
 import java.util.Set;
@@ -73,7 +72,7 @@ class Extract {
 
     ManagedChannel channel = createChannel(host);
 
-    Path root = Paths.get("blobs");
+    Path root = Path.of("blobs");
 
     downloadActionContents(root, instanceName, actionDigests.build(), channel);
 

--- a/src/main/java/build/buildfarm/tools/Mount.java
+++ b/src/main/java/build/buildfarm/tools/Mount.java
@@ -31,7 +31,6 @@ import io.grpc.ManagedChannel;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -43,7 +42,7 @@ class Mount {
     ManagedChannel channel = createChannel(host);
     Instance instance = new StubInstance(instanceName, channel);
 
-    Path cwd = Paths.get(".");
+    Path cwd = Path.of(".");
 
     FuseCAS fuse =
         new FuseCAS(

--- a/src/main/java/build/buildfarm/tools/Upload.java
+++ b/src/main/java/build/buildfarm/tools/Upload.java
@@ -17,7 +17,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -44,7 +43,7 @@ class Upload {
     String host = args[0];
     String instanceName = args[1];
     DigestUtil digestUtil = DigestUtil.forHash(args[2]);
-    Path path = Paths.get(args[3]);
+    Path path = Path.of(args[3]);
     main(host, instanceName, digestUtil, path);
   }
 }

--- a/src/main/java/build/buildfarm/tools/WorkerProfile.java
+++ b/src/main/java/build/buildfarm/tools/WorkerProfile.java
@@ -33,7 +33,7 @@ import com.google.protobuf.util.Durations;
 import com.google.protobuf.util.JsonFormat;
 import io.grpc.StatusRuntimeException;
 import java.io.IOException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -104,7 +104,7 @@ class WorkerProfile {
       throw new IllegalArgumentException("Missing Config_PATH");
     }
     try {
-      configs.loadConfigs(Paths.get(residue.get(3)));
+      configs.loadConfigs(Path.of(residue.get(3)));
     } catch (IOException e) {
       System.out.println("Could not parse yml configuration file." + e);
     }

--- a/src/main/java/build/buildfarm/worker/DockerExecutor.java
+++ b/src/main/java/build/buildfarm/worker/DockerExecutor.java
@@ -39,7 +39,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -352,7 +351,7 @@ public class DockerExecutor {
   private static void mountExecRoot(HostConfig config, Path execDir) {
     // decide paths
     List<Path> paths = new ArrayList<>();
-    paths.add(Paths.get("/" + execDir.subpath(0, 1)));
+    paths.add(Path.of("/" + execDir.subpath(0, 1)));
     paths.add(execDir);
     paths.addAll(Utils.getSymbolicLinkReferences(execDir));
     // mount paths needed for the execution root

--- a/src/main/java/build/buildfarm/worker/cgroup/Group.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/Group.java
@@ -22,7 +22,6 @@ import io.grpc.Deadline;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.Nonnull;
@@ -36,7 +35,7 @@ import lombok.extern.java.Log;
 @Log
 public final class Group {
   @Getter private static final Group root = new Group(/* name= */ null, /* parent= */ null);
-  private static final Path rootPath = Paths.get("/sys/fs/cgroup");
+  private static final Path rootPath = Path.of("/sys/fs/cgroup");
   private static final POSIX posix = POSIXFactory.getNativePOSIX();
 
   @Getter @Nullable private final String name;

--- a/src/main/java/build/buildfarm/worker/persistent/PersistentExecutor.java
+++ b/src/main/java/build/buildfarm/worker/persistent/PersistentExecutor.java
@@ -30,7 +30,6 @@ import com.google.rpc.Code;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -52,7 +51,7 @@ public class PersistentExecutor {
       ProtoCoordinator.ofCommonsPool(getMaxWorkersPerKey());
 
   // TODO load from config (i.e. {worker_root}/persistent)
-  public static final Path defaultWorkRootsDir = Paths.get("/tmp/worker/persistent/");
+  public static final Path defaultWorkRootsDir = Path.of("/tmp/worker/persistent/");
 
   public static final String PERSISTENT_WORKER_FLAG = "--persistent_worker";
 
@@ -143,7 +142,7 @@ public class PersistentExecutor {
 
     WorkerInputs workerFiles = WorkerInputs.from(context, requestArgs);
 
-    Path binary = Paths.get(workerExecCmd.getFirst());
+    Path binary = Path.of(workerExecCmd.getFirst());
     if (!workerFiles.containsTool(binary) && !binary.isAbsolute()) {
       throw new IllegalArgumentException(
           "Binary wasn't a tool input nor an absolute path: " + binary);

--- a/src/main/java/build/buildfarm/worker/persistent/ProtoCoordinator.java
+++ b/src/main/java/build/buildfarm/worker/persistent/ProtoCoordinator.java
@@ -23,7 +23,6 @@ import com.google.protobuf.util.Durations;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.UUID;
@@ -225,7 +224,7 @@ public class ProtoCoordinator extends WorkCoordinator<RequestCtx, ResponseCtx, C
     Path opRoot = context.opRoot;
 
     for (String outputDir : context.outputDirectories) {
-      Path outputDirPath = Paths.get(outputDir);
+      Path outputDirPath = Path.of(outputDir);
       Files.createDirectories(outputDirPath);
     }
 

--- a/src/test/java/build/buildfarm/cas/cfc/HexBucketEntryPathStrategyTest.java
+++ b/src/test/java/build/buildfarm/cas/cfc/HexBucketEntryPathStrategyTest.java
@@ -18,7 +18,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static java.lang.String.format;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Iterator;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,7 +27,7 @@ import org.junit.runners.JUnit4;
 public class HexBucketEntryPathStrategyTest {
   @Test
   public void branchDirectoriesNoLevelsIsEmpty() {
-    Path path = Paths.get("cache");
+    Path path = Path.of("cache");
     EntryPathStrategy entryPathStrategy = new HexBucketEntryPathStrategy(path, 0);
 
     Iterator<Path> paths = entryPathStrategy.branchDirectories().iterator();
@@ -37,7 +36,7 @@ public class HexBucketEntryPathStrategyTest {
 
   @Test
   public void branchDirectoriesSingleLevelsIsRoot() {
-    Path path = Paths.get("cache");
+    Path path = Path.of("cache");
     EntryPathStrategy entryPathStrategy = new HexBucketEntryPathStrategy(path, 1);
 
     Iterator<Path> paths = entryPathStrategy.branchDirectories().iterator();
@@ -49,7 +48,7 @@ public class HexBucketEntryPathStrategyTest {
 
   @Test
   public void branchDirectoriesMultipleLevels() {
-    Path path = Paths.get("cache");
+    Path path = Path.of("cache");
     EntryPathStrategy entryPathStrategy = new HexBucketEntryPathStrategy(path, 2);
 
     Iterator<Path> paths = entryPathStrategy.branchDirectories().iterator();
@@ -66,7 +65,7 @@ public class HexBucketEntryPathStrategyTest {
 
   @Test
   public void getPathMatchesLevels() {
-    Path path = Paths.get("cache");
+    Path path = Path.of("cache");
     EntryPathStrategy entryPathStrategy = new HexBucketEntryPathStrategy(path, 2);
 
     String key = "aa55bb1100bb";

--- a/src/test/java/build/buildfarm/common/CommandUtilsTest.java
+++ b/src/test/java/build/buildfarm/common/CommandUtilsTest.java
@@ -18,7 +18,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import build.bazel.remote.execution.v2.Command;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,11 +38,11 @@ public class CommandUtilsTest {
     Command command = Command.newBuilder().addOutputPaths("foo0").addOutputPaths("foo1").build();
 
     // ACT
-    List<Path> paths = CommandUtils.getResolvedOutputPaths(command, Paths.get("root"));
+    List<Path> paths = CommandUtils.getResolvedOutputPaths(command, Path.of("root"));
 
     // ASSERT
-    assertThat(paths.get(0).toString()).isEqualTo(Paths.get("root/foo0").toString());
-    assertThat(paths.get(1).toString()).isEqualTo(Paths.get("root/foo1").toString());
+    assertThat(paths.get(0).toString()).isEqualTo(Path.of("root/foo0").toString());
+    assertThat(paths.get(1).toString()).isEqualTo(Path.of("root/foo1").toString());
   }
 
   // Function under test: getResolvedOutputPaths
@@ -55,10 +54,10 @@ public class CommandUtilsTest {
     Command command = Command.newBuilder().addOutputFiles("foo0").addOutputFiles("foo1").build();
 
     // ACT
-    List<Path> paths = CommandUtils.getResolvedOutputPaths(command, Paths.get("root"));
+    List<Path> paths = CommandUtils.getResolvedOutputPaths(command, Path.of("root"));
 
     // ASSERT
-    assertThat(paths.get(0).toString()).isEqualTo(Paths.get("root/foo0").toString());
-    assertThat(paths.get(1).toString()).isEqualTo(Paths.get("root/foo1").toString());
+    assertThat(paths.get(0).toString()).isEqualTo(Path.of("root/foo0").toString());
+    assertThat(paths.get(1).toString()).isEqualTo(Path.of("root/foo1").toString());
   }
 }

--- a/src/test/java/build/buildfarm/examples/ExampleConfigsTest.java
+++ b/src/test/java/build/buildfarm/examples/ExampleConfigsTest.java
@@ -17,7 +17,6 @@ package build.buildfarm.examples;
 import build.buildfarm.common.config.BuildfarmConfigs;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,14 +34,14 @@ public class ExampleConfigsTest {
   @Test
   public void shardWorkerConfig() throws IOException {
     Path configPath =
-        Paths.get(System.getenv("TEST_SRCDIR"), "_main", "examples", "config.minimal.yml");
+        Path.of(System.getenv("TEST_SRCDIR"), "_main", "examples", "config.minimal.yml");
     BuildfarmConfigs configs = BuildfarmConfigs.getInstance();
     configs.loadConfigs(configPath);
   }
 
   @Test
   public void fullConfig() throws IOException {
-    Path configPath = Paths.get(System.getenv("TEST_SRCDIR"), "_main", "examples", "config.yml");
+    Path configPath = Path.of(System.getenv("TEST_SRCDIR"), "_main", "examples", "config.yml");
     BuildfarmConfigs configs = BuildfarmConfigs.getInstance();
     configs.loadConfigs(configPath);
   }

--- a/src/test/java/build/buildfarm/worker/ExecuteActionStageTest.java
+++ b/src/test/java/build/buildfarm/worker/ExecuteActionStageTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.when;
 
 import build.buildfarm.v1test.ExecuteEntry;
 import build.buildfarm.v1test.QueueEntry;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -41,7 +41,7 @@ public class ExecuteActionStageTest {
     ExecutionContext errorContext =
         ExecutionContext.newBuilder()
             .setQueueEntry(errorEntry)
-            .setExecDir(Paths.get("error-operation-path"))
+            .setExecDir(Path.of("error-operation-path"))
             .build();
 
     PipelineStage executeActionStage = new ExecuteActionStage(context, /* output= */ null, error);

--- a/src/test/java/build/buildfarm/worker/InputFetcherTest.java
+++ b/src/test/java/build/buildfarm/worker/InputFetcherTest.java
@@ -49,7 +49,6 @@ import com.google.rpc.Status;
 import java.io.IOException;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
@@ -94,9 +93,9 @@ public class InputFetcherTest {
               Action action,
               Command command)
               throws IOException {
-            Path root = Paths.get(operationName);
+            Path root = Path.of(operationName);
             throw new ExecDirException(
-                Paths.get(operationName),
+                Path.of(operationName),
                 ImmutableList.of(
                     new ViolationException(
                         Digest.getDefaultInstance(),

--- a/src/test/java/build/buildfarm/worker/ReportResultStageTest.java
+++ b/src/test/java/build/buildfarm/worker/ReportResultStageTest.java
@@ -43,7 +43,7 @@ import com.google.protobuf.Any;
 import com.google.rpc.Code;
 import com.google.rpc.Status;
 import io.grpc.protobuf.StatusProto;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.logging.Logger;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -106,7 +106,7 @@ public class ReportResultStageTest {
             .setAction(Action.newBuilder().setDoNotCache(true).build())
             .setOperation(reportedOperation)
             .setQueueEntry(reportedEntry)
-            .setExecDir(Paths.get("reported-operation-path"))
+            .setExecDir(Path.of("reported-operation-path"))
             .setPoller(mock(Poller.class))
             .build();
     when(context.getReportResultStageWidth()).thenReturn(1);
@@ -149,7 +149,7 @@ public class ReportResultStageTest {
             .setAction(action)
             .setOperation(erroringOperation)
             .setQueueEntry(erroringEntry)
-            .setExecDir(Paths.get("erroring-operation-path"))
+            .setExecDir(Path.of("erroring-operation-path"))
             .setPoller(mock(Poller.class))
             .build();
     when(context.getReportResultStageWidth()).thenReturn(1);

--- a/src/test/java/build/buildfarm/worker/util/InputsIndexerTest.java
+++ b/src/test/java/build/buildfarm/worker/util/InputsIndexerTest.java
@@ -43,7 +43,7 @@ public class InputsIndexerTest {
   @Test
   public void basicEmptyTree() {
     Tree emptyTree = Tree.newBuilder().build();
-    InputsIndexer indexer = new InputsIndexer(emptyTree, Paths.get("."));
+    InputsIndexer indexer = new InputsIndexer(emptyTree, Path.of("."));
     assertThat(indexer.tree).isEqualTo(emptyTree);
   }
 
@@ -55,7 +55,7 @@ public class InputsIndexerTest {
     Digest rootDirDigest = addDirToTree(treeBuilder, "my_root_dir", rootDir);
     treeBuilder.setRootDigest(rootDirDigest);
 
-    Path arbitraryOpRoot = Paths.get(".");
+    Path arbitraryOpRoot = Path.of(".");
 
     InputsIndexer indexer = new InputsIndexer(treeBuilder.build(), arbitraryOpRoot);
     assertThat(indexer.proxyDirs.get(DigestUtil.toDigest(rootDirDigest))).isEqualTo(rootDir);
@@ -72,7 +72,7 @@ public class InputsIndexerTest {
     Digest rootDirDigest = addDirToTree(treeBuilder, "my_root_dir", rootDir);
     treeBuilder.setRootDigest(rootDirDigest);
 
-    Path arbitraryOpRoot = Paths.get("asdf");
+    Path arbitraryOpRoot = Path.of("asdf");
     InputsIndexer indexer = new InputsIndexer(treeBuilder.build(), arbitraryOpRoot);
     assertThat(indexer.proxyDirs.get(DigestUtil.toDigest(rootDirDigest))).isEqualTo(rootDir);
 
@@ -112,7 +112,7 @@ public class InputsIndexerTest {
     Digest rootDirDigest = addDirToTree(treeBuilder, "my_root_dir", rootDir);
     treeBuilder.setRootDigest(rootDirDigest);
 
-    Path arbitraryOpRoot = Paths.get("asdf");
+    Path arbitraryOpRoot = Path.of("asdf");
 
     InputsIndexer indexer = new InputsIndexer(treeBuilder.build(), arbitraryOpRoot);
     assertThat(indexer.proxyDirs.get(DigestUtil.toDigest(rootDirDigest))).isEqualTo(rootDir);

--- a/src/test/java/build/buildfarm/worker/util/WorkerTestUtils.java
+++ b/src/test/java/build/buildfarm/worker/util/WorkerTestUtils.java
@@ -34,7 +34,6 @@ import java.nio.file.FileVisitResult;
 import java.nio.file.FileVisitor;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -130,7 +129,7 @@ public class WorkerTestUtils {
     }
 
     public String name() {
-      return Paths.get(this.path).getFileName().toString();
+      return Path.of(this.path).getFileName().toString();
     }
   }
 
@@ -152,7 +151,7 @@ public class WorkerTestUtils {
           props = makeNodeProperties(ImmutableMap.of(BAZEL_TOOL_INPUT_MARKER, ""));
         }
         FileNode fileNode = makeFileNode(file.name(), file.content, props);
-        Path parentDirPath = Paths.get(file.path).getParent();
+        Path parentDirPath = Path.of(file.path).getParent();
         if (parentDirPath != null) {
           String parentDirPathStr = parentDirPath.normalize().toString();
           Directory.Builder parentDirBuilder =


### PR DESCRIPTION
`Path.of()` is preferred for Java11+ (`Paths.get(...)` delegates to `Path.of(...)`)

openrewrite-rule: https://docs.openrewrite.org/recipes/java/migrate/nio/file/pathsgettopathof
