### PR TITLE
fix(persistentworkers): clear host environment vars for persistent wo…

### DIFF
--- a/persistentworkers/src/main/java/persistent/common/processes/ProcessWrapper.java
+++ b/persistentworkers/src/main/java/persistent/common/processes/ProcessWrapper.java
@@ -65,7 +65,7 @@ public class ProcessWrapper implements Closeable {
             .command(this.args)
             .directory(this.workRoot.toFile())
             .redirectError(ProcessBuilder.Redirect.to(this.errorFile.toFile()));
-
+    pb.environment().clear();
     pb.environment().putAll(env);
 
     try {


### PR DESCRIPTION
…rker processes

Persistent worker processes should NOT inherit Buildfarm's env vars.