### PR TITLE
fix(metrics): increase histogram buckets

### DIFF
--- a/src/main/java/build/buildfarm/common/services/ContentAddressableStorageService.java
+++ b/src/main/java/build/buildfarm/common/services/ContentAddressableStorageService.java
@@ -60,7 +60,7 @@ public class ContentAddressableStorageService
     extends ContentAddressableStorageGrpc.ContentAddressableStorageImplBase {
   private static final Histogram missingBlobs =
       Histogram.build()
-          .exponentialBuckets(1, 2, 6)
+          .exponentialBuckets(1, 2, 12)
           .name("missing_blobs")
           .help("Find missing blobs.")
           .register();


### PR DESCRIPTION
Add more buckets to the `missingBlobs` Histogram.