### PR TITLE
Ensure correlatedInvocationsId is reduced to id

### DIFF
--- a/src/main/java/build/buildfarm/common/config/Backplane.java
+++ b/src/main/java/build/buildfarm/common/config/Backplane.java
@@ -42,7 +42,7 @@ public class Backplane {
   private int casExpire = 604800; // 1 Week
   private String correlatedInvocationsIndexPrefix = "CorrelatedInvocationsIndex";
   private int maxCorrelatedInvocationsIndexTimeout = 3 * 24 * 60 * 60; // 3 Days
-  private String correlatedInvocationsPrefix = "CorrelatedInvocation";
+  private String correlatedInvocationsPrefix = "CorrelatedInvocations";
   private int maxCorrelatedInvocationsTimeout = 7 * 24 * 60 * 60; // 1 Week
   private String toolInvocationsPrefix = "ToolInvocation";
   private int maxToolInvocationTimeout = 604800;

--- a/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
@@ -3167,7 +3167,7 @@ public class ServerInstance extends NodeInstance {
     if (Strings.isNullOrEmpty(id)) {
       // If the query contains a single 'id' parameter it is used
       List<String> ids = parameters.get("id");
-      if (ids.size() == 1) {
+      if (ids != null && ids.size() == 1) {
         id = ids.getFirst();
       }
     }
@@ -3182,7 +3182,7 @@ public class ServerInstance extends NodeInstance {
 
     // no unique distinction for this url exists, just use the original uri
     if (Strings.isNullOrEmpty(id)) {
-      id = decoder.uri();
+      id = uri.toString();
     }
 
     // TODO stream() to select sub-map?
@@ -3193,9 +3193,12 @@ public class ServerInstance extends NodeInstance {
 
     // associate uri components and query with this correlated id
     if (indexScopes.contains("username")) {
-      String username = uri.getUserInfo().split(":")[0];
-      if (!username.isEmpty()) {
-        indexScopeValues.put("username", ImmutableList.of(username));
+      String userInfo = uri.getUserInfo();
+      if (!Strings.isNullOrEmpty(userInfo)) {
+        String username = uri.getUserInfo().split(":")[0];
+        if (!username.isEmpty()) {
+          indexScopeValues.put("username", ImmutableList.of(username));
+        }
       }
     }
     if (indexScopes.contains("host")) {

--- a/src/test/java/build/buildfarm/instance/shard/ServerInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/ServerInstanceTest.java
@@ -1273,4 +1273,30 @@ public class ServerInstanceTest {
     int start = random.nextInt(end);
     return input.stream().skip(start).limit(end - start).collect(Collectors.toSet());
   }
+
+  @Test
+  public void indexCorrelatedInvocationsTrims() throws Exception {
+    // fragment chosen over query id
+    String uuid = "3142d81d-fc20-4e67-91e3-27072f03c1e9";
+    String correlatedInvocationsId =
+        instance.indexCorrelatedInvocations(
+            new java.net.URI("https://host.example.com/path/to/build/?id=unused&foo=bar#" + uuid));
+    assertThat(correlatedInvocationsId).isEqualTo(uuid);
+
+    // query id chosen over path
+    correlatedInvocationsId =
+        instance.indexCorrelatedInvocations(
+            new java.net.URI("https://host.example.com/path/to/build/?id=" + uuid + "&foo=bar"));
+    assertThat(correlatedInvocationsId).isEqualTo(uuid);
+
+    // path as last selected resort
+    correlatedInvocationsId =
+        instance.indexCorrelatedInvocations(new java.net.URI("https://host.example.com/" + uuid));
+    assertThat(correlatedInvocationsId).isEqualTo("/" + uuid);
+
+    // otherwise we use the uri fully
+    correlatedInvocationsId =
+        instance.indexCorrelatedInvocations(new java.net.URI("https://" + uuid));
+    assertThat(correlatedInvocationsId).isEqualTo("https://" + uuid);
+  }
 }


### PR DESCRIPTION
Prevent whole-correlatedInvocationsId selection where userInfo is null in URI. Add tests to validate filtering.