### PR TITLE
Ignore lost race to create cgroup directory

### DIFF
--- a/src/main/java/build/buildfarm/worker/cgroup/Group.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/Group.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import io.grpc.Deadline;
 import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
@@ -165,8 +166,13 @@ public final class Group {
     if (parent != null) {
       parent.create(controllerName);
       Path path = getPath(controllerName);
-      if (!Files.exists(path)) {
-        Files.createDirectory(path);
+      try {
+        if (!Files.exists(path)) {
+          Files.createDirectory(path);
+        }
+      } catch (FileAlreadyExistsException e) {
+        // per the avoidance above, we don't care that this already
+        // exists and we lost a race to create it
       }
     }
   }


### PR DESCRIPTION
Users have reported errors creating these directories. Given the File.exists check just prior, we don't really care about sequencing, only that it happens, particularly for higher levels.