### PR TITLE
Sandbox policies

### DIFF
--- a/as-nobody.c
+++ b/as-nobody.c
@@ -4,6 +4,7 @@
 #include <unistd.h>
 #include <grp.h>
 #include <string.h>
+#include <errno.h>
 
 int
 main(int argc, char *argv[])
@@ -19,8 +20,14 @@ main(int argc, char *argv[])
     username = argv[2];
     argi = 3;
   }
+  // per getpwnam, this needs to be reset before checking error
+  errno = 0;
   struct passwd *pw = getpwnam(username);
   if (pw == NULL) {
+    if (errno == 0) {
+      // also listed in documentation as a possible error status return
+      errno = ENOENT;
+    }
     perror("getpwnam");
     return EXIT_FAILURE;
   }

--- a/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
@@ -176,16 +176,6 @@ public final class ResourceDecider {
     // ignoring the request due to a disabled sandbox.
     decideSandboxUsage(limits, sandbox);
 
-    // Avoid using the existing execution policies when using the linux sandbox.
-    // Using these execution policies under the sandbox do not have the right permissions to work.
-    // For the time being, we want to experiment with dynamically choosing the sandbox-
-    // without affecting current configurations or relying on specific deployments.
-    // This will dynamically skip using the worker configured execution policies.
-    if (limits.useLinuxSandbox) {
-      limits.useExecutionPolicies = false;
-      limits.description.add("configured execution policies skipped because of choosing sandbox");
-    }
-
     // Decide whether the action will run in a container
     if (allowBringYourOwnContainer && !limits.containerSettings.containerImage.isEmpty()) {
       // enable container execution


### PR DESCRIPTION
Improve as-nobody error reporting

Looking up a non-existent user can result in a 0 errno, interpret this
as an ENOENT to reuse perror output.

Prevent execution policy disable for sandbox

Policies may have nothing to do with sandbox behavior or permissions.
Permit these to be active at the same time as the sandbox options.