### PR TITLE
Assert cgroup ownership by exec owner for tasks/procs

### DIFF
--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -305,7 +305,11 @@ class Executor {
     Code statusCode;
     try (IOResource resource =
         workerContext.limitExecution(
-            operationName, arguments, executionContext.command, workingDirectory)) {
+            operationName,
+            executionContext.claim.owner(),
+            arguments,
+            executionContext.command,
+            workingDirectory)) {
       if (System.getProperty("os.name").contains("Win")) {
         // Make sure that the executable path is absolute, otherwise processbuilder fails on windows
         Iterator<String> argumentItr = command.getArgumentsList().iterator();

--- a/src/main/java/build/buildfarm/worker/WorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/WorkerContext.java
@@ -131,6 +131,7 @@ public interface WorkerContext {
 
   IOResource limitExecution(
       String operationName,
+      @Nullable UserPrincipal owner,
       ImmutableList.Builder<String> arguments,
       Command command,
       Path workingDirectory);

--- a/src/main/java/build/buildfarm/worker/cgroup/Controller.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/Controller.java
@@ -22,6 +22,7 @@ import java.io.Reader;
 import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.UserPrincipal;
 
 abstract class Controller implements IOResource {
   protected final Group group;
@@ -78,6 +79,18 @@ abstract class Controller implements IOResource {
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  private void setOwner(String propertyName, UserPrincipal owner) throws IOException {
+    Path path = getPath().resolve(propertyName);
+    Files.setOwner(path, owner);
+  }
+
+  public void setOwner(UserPrincipal owner) throws IOException {
+    // an execution owner must be able to join a cgroup through group task/proc ownership
+    open();
+    setOwner("cgroup.procs", owner);
+    setOwner("tasks", owner);
   }
 
   protected void writeInt(String propertyName, int value) throws IOException {

--- a/src/test/java/build/buildfarm/worker/StubWorkerContext.java
+++ b/src/test/java/build/buildfarm/worker/StubWorkerContext.java
@@ -202,6 +202,7 @@ class StubWorkerContext implements WorkerContext {
   @Override
   public IOResource limitExecution(
       String operationName,
+      UserPrincipal owner,
       ImmutableList.Builder<String> arguments,
       Command command,
       Path workingDirectory) {


### PR DESCRIPTION
Failure to make the cgroup.procs or tasks file owned by the exec owner will prevent a join of the cgroup by the execution.