### PR TITLE
Fix sandbox option for tmpfs

### DIFF
--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -1006,7 +1006,7 @@ class ShardWorkerContext implements WorkerContext {
         configs.getWorker().getSandboxSettings().getAdditionalWritePaths());
 
     if (limits.tmpFs) {
-      options.writableFiles.addAll(configs.getWorker().getSandboxSettings().getTmpFsPaths());
+      options.tmpfsDirs.addAll(configs.getWorker().getSandboxSettings().getTmpFsPaths());
     }
 
     if (limits.debugAfterExecution) {


### PR DESCRIPTION
This option is incorrectly being set as writable paths instead of tmpfs. Prior to this fix, the directories are being added to the list of host paths to be sent to sandbox and not actually mounted as empty directories within sandbox.