### PR TITLE
Guard against valid null return from acquireClaim

### DIFF
--- a/persistentworkers/src/main/java/persistent/common/processes/ProcessWrapper.java
+++ b/persistentworkers/src/main/java/persistent/common/processes/ProcessWrapper.java
@@ -29,7 +29,6 @@ import lombok.extern.java.Log;
  */
 @Log
 public class ProcessWrapper implements Closeable {
-
   private final Process process;
 
   @Getter private final Path workRoot;

--- a/src/main/java/build/buildfarm/common/Dispenser.java
+++ b/src/main/java/build/buildfarm/common/Dispenser.java
@@ -1,0 +1,85 @@
+// Copyright 2025 The Buildfarm Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import java.util.AbstractCollection;
+import java.util.Iterator;
+import java.util.Queue;
+
+/**
+ * @class Dispenser
+ * @brief A queue which delivers a single element repeatedly without delay or regard for size.
+ * @details For compatibility with POOL resources, this Queue delivers an infinite immediate
+ *     sequence of an identical element.
+ */
+public final class Dispenser<T> extends AbstractCollection<T> implements Queue<T> {
+  private final T element;
+
+  public Dispenser(T element) {
+    this.element = element;
+  }
+
+  // used methods
+  @Override
+  public T poll() {
+    return element;
+  }
+
+  @Override
+  public boolean add(T o) {
+    checkState(o.equals(element));
+    return true;
+  }
+
+  // unused methods
+  // Queue
+  @Override
+  public T peek() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public T element() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public T remove() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean offer(T o) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void clear() {
+    throw new UnsupportedOperationException();
+  }
+
+  // Collection
+  @Override
+  public int size() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Iterator<T> iterator() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -292,7 +292,7 @@ class ShardWorkerContext implements WorkerContext {
 
   // FIXME make OwnedClaim with owner
   // how will this play out with persistent workers, should we have one per user?
-  private Claim acquireClaim(Platform platform) {
+  private @Nullable Claim acquireClaim(Platform platform) {
     // expand platform requirements with exec owner
     if (provideOwnedClaim) {
       platform = platform.toBuilder().addProperties(EXEC_OWNER_PROPERTY).build();
@@ -301,7 +301,7 @@ class ShardWorkerContext implements WorkerContext {
     Claim claim = DequeueMatchEvaluator.acquireClaim(matchProvisions, resourceSet, platform);
 
     // a little awkward wrapping with the early return here to preserve effective final
-    if (provideOwnedClaim) {
+    if (claim != null && provideOwnedClaim) {
       // enforced by exec owner property value of "1"
       for (Entry<String, List<Object>> pool : claim.getPools()) {
         if (!pool.getKey().equals(EXEC_OWNER_RESOURCE_NAME)) {

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -35,6 +35,7 @@ import build.buildfarm.cas.cfc.CASFileCache;
 import build.buildfarm.common.BuildfarmExecutors;
 import build.buildfarm.common.DigestUtil;
 import build.buildfarm.common.DigestUtil.HashFunction;
+import build.buildfarm.common.Dispenser;
 import build.buildfarm.common.InputStreamFactory;
 import build.buildfarm.common.LoggingMain;
 import build.buildfarm.common.ZstdDecompressingOutputStream.FixedBufferPool;
@@ -94,11 +95,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.UserPrincipal;
-import java.util.AbstractCollection;
 import java.util.ArrayDeque;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Queue;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.Executor;
@@ -329,70 +327,6 @@ public final class Worker extends LoggingMain {
           new ConfigurationException("Could not locate " + name);
       configException.initCause(e);
       throw configException;
-    }
-  }
-
-  /**
-   * @class Dispenser
-   * @brief A queue which delivers a single element repeatedly without delay or regard for size.
-   * @details For compatibility with POOL resources, this Queue delivers an infinite immediate
-   *     sequence of an identical element.
-   */
-  private static final class Dispenser<T> extends AbstractCollection<T> implements Queue<T> {
-    private final T element;
-
-    Dispenser(T element) {
-      this.element = element;
-    }
-
-    // used methods
-    @Override
-    public T poll() {
-      return element;
-    }
-
-    @Override
-    public boolean add(T o) {
-      checkState(o.equals(element));
-      return true;
-    }
-
-    // unused methods
-    // Queue
-    @Override
-    public T peek() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public T element() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public T remove() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean offer(T o) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void clear() {
-      throw new UnsupportedOperationException();
-    }
-
-    // Collection
-    @Override
-    public int size() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Iterator<T> iterator() {
-      throw new UnsupportedOperationException();
     }
   }
 


### PR DESCRIPTION
Associated test fails without the null check as before. With the null check we correctly reject the execution and continue on without a stage error.