### PR TITLE
Migrate to Cgroups v2

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -17,6 +17,7 @@ cc_binary(
 )
 
 exports_files([
+    "cgexec-wrapper",
     "delay.sh",
     "macos-wrapper.sh",
 ])

--- a/cgexec-wrapper
+++ b/cgexec-wrapper
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -e
+# This is a drop-in replacement for cgexec, with the following differences:
+#
+# - It will put child processes in a cgroup relative to THIS cgroup's parent.
+
+# Required arguments:
+# -g <controllers>:<CgroupName>
+
+# Function to display usage information
+usage() {
+    echo "Usage: $0 -g <value>" >&2
+    exit 1
+}
+
+# Parse command line arguments
+while getopts ":g:" opt; do
+  case ${opt} in
+    g )
+      # Split the value on ":" and assign to variables
+      IFS=':' read -r -a parts <<< "$OPTARG"
+      controllers="${parts[0]}"
+      cgroupName="${parts[1]}"
+      ;;
+    \? )
+      usage
+      ;;
+  esac
+done
+shift $((OPTIND -1))
+
+# Check if both variables are set, otherwise show an error message and exit
+if [ -z "$controllers" ] || [ -z "$cgroupName" ]; then
+    echo "Error: Both controllers and cgroupName must be specified." >&2
+    usage
+fi
+
+# Get my own Cgroup from /proc/self/cgroup.
+# There are three fields here, separated by ':':
+# - the group ID. This is always 0 for cgroups v2.
+# - the enabled controllers. This is always empty for cgroups v2.
+# - the cgroup Path. This is the only part we care about.
+cgroupNameRelativePath="$(cut -d':' -f3- < /proc/self/cgroup)"
+
+# This diverges from `cgexec` where we place ourselves in a group relative to parent.
+# Example:
+# cgroupName = `executions/operations/29aec796-ad19-4e6b-a83b-b8b9f55d0abb`
+# This process starts in the ${cgroupNameRelativePath} cgroup:
+#   ├─${baseCgroup}
+#   │ ├─${cgroupNameRelativePath}
+#   │ │ ├─123456 /tini -- java -jar /app/build_buildfarm/buildfarm-shard-worker_deploy.jar
+#   │ │ └─123457 java -jar /app/build_buildfarm/buildfarm-shard-worker_deploy.jar
+#   │ └─executions
+#   │   └─operations
+#   │     └─29aec796-ad19-4e6b-a83b-b8b9f55d0abb
+#   │        └─123458 ${@}
+baseCgroup=$(dirname "${cgroupNameRelativePath}")
+# Bouncing my own PID $$ into /sys/fs/cgroup${baseCgroup}/$cgroupName"
+echo $$ > "/sys/fs/cgroup${baseCgroup}/$cgroupName/cgroup.procs"
+
+# Exec the rest of the arguments as-is
+exec "$@"

--- a/container/BUILD
+++ b/container/BUILD
@@ -104,6 +104,7 @@ pkg_files(
     }) + [
         # keep sorted
         "//:as-nobody",
+        "//:cgexec-wrapper",
         "//:macos-wrapper.sh",
         "@bazel//src/main/tools:linux-sandbox",
         "@bazel//src/main/tools:process-wrapper",

--- a/src/main/java/build/buildfarm/common/config/ExecutionWrappers.java
+++ b/src/main/java/build/buildfarm/common/config/ExecutionWrappers.java
@@ -30,7 +30,7 @@ public class ExecutionWrappers {
    * @brief The program to use when running actions under cgroups.
    * @details This program is expected to be packaged with the worker image.
    */
-  private String cgroups = "/usr/bin/cgexec";
+  private String cgroups = "/app/build_buildfarm/cgexec-wrapper";
 
   /**
    * @field unshare

--- a/src/main/java/build/buildfarm/worker/cgroup/CGroupVersion.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/CGroupVersion.java
@@ -1,0 +1,6 @@
+package build.buildfarm.worker.cgroup;
+
+public enum CGroupVersion {
+  NONE, /* CGroups not detected at all */
+  CGROUPS_V2,
+}

--- a/src/main/java/build/buildfarm/worker/cgroup/Controller.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/Controller.java
@@ -90,7 +90,6 @@ abstract class Controller implements IOResource {
     // an execution owner must be able to join a cgroup through group task/proc ownership
     open();
     setOwner("cgroup.procs", owner);
-    setOwner("tasks", owner);
   }
 
   protected void writeInt(String propertyName, int value) throws IOException {

--- a/src/main/java/build/buildfarm/worker/cgroup/Controller.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/Controller.java
@@ -33,15 +33,15 @@ abstract class Controller implements IOResource {
     this.group = group;
   }
 
-  public abstract String getName();
+  public abstract String getControllerName();
 
   protected final Path getPath() {
-    return group.getPath(getName());
+    return group.getPath();
   }
 
   protected final void open() throws IOException {
     if (!opened) {
-      group.create(getName());
+      group.create(getControllerName());
       opened = true;
     }
   }
@@ -58,7 +58,7 @@ abstract class Controller implements IOResource {
     Path path = getPath();
     boolean exists = true;
     while (exists) {
-      group.killUntilEmpty(getName());
+      group.killUntilEmpty();
       try {
         Files.delete(path);
         exists = false;
@@ -75,7 +75,7 @@ abstract class Controller implements IOResource {
   @Override
   public boolean isReferenced() {
     try {
-      return !group.isEmpty(getName());
+      return !group.isEmpty();
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -97,6 +97,13 @@ abstract class Controller implements IOResource {
     Path path = getPath().resolve(propertyName);
     try (Writer out = new OutputStreamWriter(Files.newOutputStream(path))) {
       out.write(String.format("%d\n", value));
+    }
+  }
+
+  protected void writeIntPair(String propertyName, int value, int value2) throws IOException {
+    Path path = getPath().resolve(propertyName);
+    try (Writer out = new OutputStreamWriter(Files.newOutputStream(path))) {
+      out.write(String.format("%d %d\n", value, value2));
     }
   }
 

--- a/src/main/java/build/buildfarm/worker/cgroup/Cpu.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/Cpu.java
@@ -30,16 +30,21 @@ public class Cpu extends Controller {
   }
 
   /**
-   * Represents how much CPU shares are allocated. Note - this method does nothing for CGroups v2.
-   * All processes get equal weight.
+   * Represents how much CPU shares are allocated.
    *
+   * @see <a
+   *     href="https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html#weights">Cgroups
+   *     v2: Weights</a>
    * @param shares
    * @throws IOException
    */
-  @Deprecated
   public void setShares(int shares) throws IOException {
-    open();
-    // TODO what to do for cgroups v2?
+    if (shares > 0) {
+      open();
+      // cpu.weight in the range [1,1000]
+      // the default is 100, so we want to set something every time.
+      writeInt("cpu.weight", shares);
+    }
   }
 
   /**

--- a/src/main/java/build/buildfarm/worker/cgroup/Cpu.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/Cpu.java
@@ -17,37 +17,44 @@ package build.buildfarm.worker.cgroup;
 import java.io.IOException;
 
 public class Cpu extends Controller {
+
+  private final int CPU_GRANULARITY = 100_000; // microseconds (μS)
+
   Cpu(Group group) {
     super(group);
   }
 
   @Override
-  public String getName() {
+  public String getControllerName() {
     return "cpu";
   }
 
+  @Deprecated(forRemoval = true)
   public int getShares() throws IOException {
     open();
     return readLong("cpu.shares");
   }
 
+  /**
+   * Represents how much CPU shares are allocated. Note - this method does nothing for CGroups v2.
+   * All processes get equal weight.
+   *
+   * @param shares
+   * @throws IOException
+   */
+  @Deprecated
   public void setShares(int shares) throws IOException {
     open();
-    writeInt("cpu.shares", shares);
+    // TODO what to do for cgroups v2?
   }
 
-  public int getCFSPeriod() throws IOException {
+  /**
+   * Set the maximum number of cores.
+   *
+   * @param cpuCores whole cores. 1 == 1 CPU core.
+   */
+  public void setMaxCpu(int cpuCores) throws IOException {
     open();
-    return readLong("cpu.cfs_period_us");
-  }
-
-  public void setCFSPeriod(int microseconds) throws IOException {
-    open();
-    writeInt("cpu.cfs_period_us", microseconds);
-  }
-
-  public void setCFSQuota(int microseconds) throws IOException {
-    open();
-    writeInt("cpu.cfs_quota_us", microseconds);
+    writeIntPair("cpu.max", cpuCores * CPU_GRANULARITY, CPU_GRANULARITY);
   }
 }

--- a/src/main/java/build/buildfarm/worker/cgroup/Cpu.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/Cpu.java
@@ -29,12 +29,6 @@ public class Cpu extends Controller {
     return "cpu";
   }
 
-  @Deprecated(forRemoval = true)
-  public int getShares() throws IOException {
-    open();
-    return readLong("cpu.shares");
-  }
-
   /**
    * Represents how much CPU shares are allocated. Note - this method does nothing for CGroups v2.
    * All processes get equal weight.

--- a/src/main/java/build/buildfarm/worker/cgroup/Cpu.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/Cpu.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 
 public class Cpu extends Controller {
 
-  private final int CPU_GRANULARITY = 100_000; // microseconds (μS)
+  private static final int CPU_GRANULARITY = 100_000; // microseconds (μS)
 
   Cpu(Group group) {
     super(group);

--- a/src/main/java/build/buildfarm/worker/cgroup/Group.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/Group.java
@@ -143,22 +143,6 @@ public final class Group {
     return parent.getHierarchy() + "/" + getName();
   }
 
-  /**
-   * Get hierarchy of this cgroup and all parents. Includes the controller name.
-   *
-   * <p>This is for CGroups v1 only.
-   *
-   * @param controllerName
-   * @return
-   */
-  String getHierarchy(String controllerName) {
-    if (parent != null) {
-      return parent.getHierarchy(controllerName) + "/" + getName();
-    }
-    return "";
-  }
-
-  /* use for cgroups v2 */
   Path getPath() {
     return rootPath.resolve(getHierarchy());
   }

--- a/src/main/java/build/buildfarm/worker/cgroup/Group.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/Group.java
@@ -14,17 +14,30 @@
 
 package build.buildfarm.worker.cgroup;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Streams;
 import io.grpc.Deadline;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import jnr.constants.platform.Signal;
@@ -36,27 +49,88 @@ import lombok.extern.java.Log;
 @Log
 public final class Group {
   @Getter private static final Group root = new Group(/* name= */ null, /* parent= */ null);
-  private static final Path rootPath = Path.of("/sys/fs/cgroup");
+  private static final Path rootPath = getSelfCgroup();
   private static final POSIX posix = POSIXFactory.getNativePOSIX();
+
+  private static final String CGROUP_CONTROLLERS = "cgroup.controllers";
+  private static final String CGROUP_SUBTREE_CONTROL = "cgroup.subtree_control";
 
   @Getter @Nullable private final String name;
   @Nullable private final Group parent;
   @Getter private final Cpu cpu;
   @Getter private final Mem mem;
 
-  @SuppressWarnings("NullableProblems")
-  private Group(String name, Group parent) {
+  @SuppressWarnings("PMD.MutableStaticState") // Unit tests set this.
+  protected static CGroupVersion VERSION = discoverCgroupVersion();
+
+  private static CGroupVersion discoverCgroupVersion() {
+    /* Try to figure out which version of CGroups is available. */
+    try {
+      List<String> allMounts = Files.readAllLines(Paths.get("/proc/mounts"));
+      for (String mount : allMounts) {
+        String[] split = mount.split("\\s+");
+        // split[0]: the block
+        // split[1]: mountpoint
+        // split[2]: fs type
+        checkState(split.length >= 3, "could not parse /proc/mounts");
+        if (split[2].contains("cgroup")) {
+          if (split[2].equals("cgroup2")) {
+            return CGroupVersion.CGROUPS_V2;
+          }
+        }
+        // by this point, we haven't found any `cgroup` or `cgroup2` fs types.
+      }
+    } catch (IOException e) {
+      log.log(
+          Level.WARNING,
+          "failed to read mounts to determine CGroups version. Fallback to No CGroups.",
+          e);
+      return CGroupVersion.NONE;
+    }
+    // Give up.
+    return CGroupVersion.NONE;
+  }
+
+  static Path getSelfCgroup() {
+    try {
+      String myCgroup = Files.readString(Paths.get("/proc/self/cgroup"));
+      // This always starts with "0::" for CGroups v2.
+      if (myCgroup.startsWith("0::")) {
+        VERSION = CGroupVersion.CGROUPS_V2;
+        return Path.of("/sys/fs/cgroup", myCgroup.substring(3).trim());
+      }
+    } catch (IOException ioe) {
+      log.log(Level.SEVERE, "Cannot read my own cgroup!", ioe);
+    }
+    return Paths.get("/sys/fs/cgroup");
+  }
+
+  private Group(@Nullable String name, @Nullable Group parent) {
     this.name = name;
     this.parent = parent;
     cpu = new Cpu(this);
     mem = new Mem(this);
   }
 
+  /**
+   * Construct a child group from this group.
+   *
+   * @param name Child CGroup name
+   * @return another Group.
+   */
   public Group getChild(String name) {
     return new Group(name, this);
   }
 
+  /**
+   * Get hierarchy of this cgroup and all parents.
+   *
+   * <p>This is for CGroups v2 only.
+   *
+   * @return
+   */
   public String getHierarchy() {
+    checkState(VERSION == CGroupVersion.CGROUPS_V2);
     /* is root */
     if (parent == null) {
       return "";
@@ -69,45 +143,29 @@ public final class Group {
     return parent.getHierarchy() + "/" + getName();
   }
 
+  /**
+   * Get hierarchy of this cgroup and all parents. Includes the controller name.
+   *
+   * <p>This is for CGroups v1 only.
+   *
+   * @param controllerName
+   * @return
+   */
   String getHierarchy(String controllerName) {
     if (parent != null) {
       return parent.getHierarchy(controllerName) + "/" + getName();
     }
-    return controllerName;
+    return "";
   }
 
-  /**
-   * Get the filesystem path to the given controller for <c>this</c> CGroup.
-   *
-   * <p>This is for CGroups v1. Starts with '/sys/fs/cgroup'.
-   *
-   * @param controllerName CGroup v1 Controller name, such as "cpu" or "mem".
-   * @return Filesystem path to the CGroup's controller.
-   */
-  Path getPath(String controllerName) {
-    return rootPath.resolve(getHierarchy(controllerName));
-  }
-
-  /**
-   * Get the filesystem path to the given controller for <c>this</c> CGroup.
-   *
-   * <p>This is for CGroups v2. Starts with '/sys/fs/cgroup'.
-   *
-   * @return Filesystem path to the CGroup.
-   */
+  /* use for cgroups v2 */
   Path getPath() {
     return rootPath.resolve(getHierarchy());
   }
 
-  /**
-   * Determine if the controller is applied to any processes
-   *
-   * @param controllerName The CGroup v1 controller
-   * @return <c>true</c> if there are any processes under control of the given controller name in
-   *     this cgroup, <c>false</c> otherwise.
-   */
-  boolean isEmpty(String controllerName) throws IOException {
-    return getPids(controllerName).isEmpty();
+  boolean isEmpty() throws IOException {
+    checkState(VERSION == CGroupVersion.CGROUPS_V2);
+    return getPids().isEmpty();
   }
 
   /**
@@ -116,22 +174,18 @@ public final class Group {
    * @param processIds Process IDs to send a signal to
    */
   private void killAllProcesses(Iterable<Integer> processIds) {
-    for (int pid : processIds) {
-      posix.kill(pid, Signal.SIGKILL.intValue());
-    }
+    Streams.stream(processIds)
+        .forEach(processId -> posix.kill(processId, Signal.SIGKILL.intValue()));
   }
 
-  /**
-   * Get the list of Process IDs in a given CGroup by name.
-   *
-   * @param controllerName cgroup name, relative to cgroup root.
-   * @return Set of process IDs or empty set if the CGroup is currently empty.
-   * @throws IOException if the CGroup process list cannot be read or parsed.
-   */
   @VisibleForTesting
   @Nonnull
-  Set<Integer> getPids(String controllerName) throws IOException {
-    Path path = getPath(controllerName);
+  Set<Integer> getPids() {
+    checkState(VERSION == CGroupVersion.CGROUPS_V2, "Only applicable for cgroups v2");
+    return getPids(getPath());
+  }
+
+  private Set<Integer> getPids(Path path) {
     Path procs = path.resolve("cgroup.procs");
     try {
       return Files.readAllLines(procs).stream()
@@ -139,19 +193,56 @@ public final class Group {
           .collect(ImmutableSet.toImmutableSet());
     } catch (IOException e) {
       if (Files.exists(path)) {
-        throw e;
+        log.log(Level.WARNING, "Unable to get PIDs for Cgroup at {0}", procs);
       }
       // nonexistent controller path means no processes
       return ImmutableSet.of();
     }
   }
 
-  public void killUntilEmpty(String controllerName) throws IOException {
+  /**
+   * Move some processes into this CGroup.
+   *
+   * @param pids
+   * @see <a
+   *     href="https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html#organizing-processes-and-threads">Organizing
+   *     Processes and Threads</a>
+   */
+  void adoptPids(Iterable<Integer> pids) {
+    Path path = getPath().resolve("cgroup.procs");
+    verify(Files.exists(path), "cgroup procs doesn't exist");
+    // Only one process can be migrated on a single write(2) call.
+    for (Integer pid : pids) {
+      try {
+        try (Writer out = new OutputStreamWriter(Files.newOutputStream(path))) {
+          out.write(String.format("%d\n", pid));
+        }
+      } catch (IOException e) {
+        log.log(
+            Level.WARNING,
+            "process ID " + pid + " could not be moved to CGroup " + getPath() + "; continuing",
+            e);
+      }
+    }
+  }
+
+  /* package */ void killUntilEmpty() throws IOException {
+    if (VERSION == CGroupVersion.CGROUPS_V2) {
+      killUntilEmpty(this::getPids);
+    } else if (VERSION == CGroupVersion.NONE) {
+      throw new RuntimeException("Cannot kill empty group without CGroups support!");
+    }
+  }
+
+  /**
+   * Kill all processes in this CGroup until they are terminated
+   *
+   * @throws IOException
+   */
+  private void killUntilEmpty(@Nonnull Supplier<Set<Integer>> pidProvider) throws IOException {
     Deadline deadline = Deadline.after(1, SECONDS);
     Set<Integer> prevPids = new HashSet<>();
-    for (Set<Integer> pids = getPids(controllerName);
-        !pids.isEmpty();
-        pids = getPids(controllerName)) {
+    for (Set<Integer> pids = pidProvider.get(); !pids.isEmpty(); pids = pidProvider.get()) {
       killAllProcesses(pids);
       if (deadline.isExpired() || !pids.equals(prevPids)) {
         deadline = Deadline.after(1, SECONDS);
@@ -161,19 +252,116 @@ public final class Group {
     }
   }
 
-  void create(String controllerName) throws IOException {
+  static void ensureControllerIsEnabled(Path cgroupPath, Set<String> controllerNames)
+      throws IOException {
+    ensureControllerIsEnabled(cgroupPath, controllerNames, false);
+  }
+
+  /**
+   * For a given cgroup hierarchy path, ensure that the controller name is enabled. Otherwise, the
+   * limits are not enforced.
+   *
+   * @param cgroupPath
+   * @param controllerNames - example 'mem', 'cpu'
+   */
+  static void ensureControllerIsEnabled(
+      @Nonnull Path cgroupPath, @Nonnull Set<String> controllerNames, boolean setSubtreeControl)
+      throws IOException {
+    checkState(VERSION == CGroupVersion.CGROUPS_V2);
+    if (cgroupPath == null) {
+      return;
+    }
+    checkNotNull(controllerNames, "Controller names is null");
+    checkArgument(!controllerNames.isEmpty(), "Controller names is empty and shouldn't be");
+    // set parent folder before we handle this one.
+    if (cgroupPath.equals(rootPath.getParent())) {
+      // Recursion sentinel.
+      return;
+    }
+    ensureControllerIsEnabled(cgroupPath.getParent(), controllerNames, true);
+
+    // By now, all recursive parents of `cgroupPath` already have subcontrollers set.
+    // Finally, we make our new cgroup, if it doesn't exist.
+    try {
+      if (!Files.exists(cgroupPath)) {
+        Files.createDirectory(cgroupPath);
+      }
+    } catch (FileAlreadyExistsException e) {
+      // per the avoidance above, we don't care that this already
+      // exists and we lost a race to create it
+    }
+
+    if (setSubtreeControl) {
+      Path cgroupControllerPath = cgroupPath.resolve(CGROUP_CONTROLLERS);
+      while (!Files.exists(cgroupControllerPath)) {
+        /* busy loop */
+        log.log(Level.SEVERE, "Waiting for {0}", cgroupControllerPath);
+      }
+      Set<String> availableControllers =
+          Arrays.stream(Files.readString(cgroupControllerPath).split("\\s+"))
+              .collect(Collectors.toSet());
+      if (availableControllers.isEmpty()) {
+        throw new IllegalStateException(
+            "There are no controllers at all in CGroup at path " + cgroupPath);
+      }
+      if (!availableControllers.containsAll(controllerNames)) {
+        Set<String> desiredAndNotAvailable = new HashSet<>(controllerNames);
+        desiredAndNotAvailable.removeAll(controllerNames);
+        throw new IllegalStateException(
+            "Some controllers not enabled in CGroup at path "
+                + cgroupPath
+                + ". Only found "
+                + availableControllers
+                + ", missing "
+                + desiredAndNotAvailable);
+      }
+      Path cgroupSubtreeControlPath = cgroupPath.resolve(CGROUP_SUBTREE_CONTROL);
+      while (!Files.exists(cgroupSubtreeControlPath)) {
+        /* busy loop */
+        log.log(Level.FINE, "Waiting for {0}", cgroupSubtreeControlPath);
+      }
+      Set<String> alreadyEnabledControllers =
+          Arrays.stream(Files.readString(cgroupSubtreeControlPath).split("\\s+"))
+              .collect(Collectors.toSet());
+      log.log(Level.FINE, "Existing sub_tree control: {0}", alreadyEnabledControllers);
+      if (!alreadyEnabledControllers.containsAll(controllerNames)) {
+        log.log(
+            Level.FINE,
+            "Adding "
+                + controllerNames
+                + " to cgroup sub controller at "
+                + cgroupSubtreeControlPath);
+        try (Writer out = new OutputStreamWriter(Files.newOutputStream(cgroupSubtreeControlPath))) {
+          for (String controllerName : controllerNames) {
+            out.write(String.format("+%s ", controllerName));
+          }
+        }
+      }
+    }
+  }
+
+  void create(@Nonnull String controllerName) throws IOException {
     /* root already has all controllers created */
+    if (!root.isEmpty()) {
+      Group evacuation = root.getChild("evacuation");
+      if (Files.exists(evacuation.getPath())) {
+        // Clean it up.
+        Files.delete(evacuation.getPath());
+      }
+      Files.createDirectory(evacuation.getPath());
+      evacuation.adoptPids(root.getPids());
+      verify(root.isEmpty(), "tried to evacuate root cgroup but there were processes remaining");
+      ensureControllerIsEnabled(root.getPath(), Set.of("cpu", "memory"), true);
+    }
     if (parent != null) {
       parent.create(controllerName);
-      Path path = getPath(controllerName);
-      try {
-        if (!Files.exists(path)) {
-          Files.createDirectory(path);
-        }
-      } catch (FileAlreadyExistsException e) {
-        // per the avoidance above, we don't care that this already
-        // exists and we lost a race to create it
-      }
+      // Write "cgroup.subtree_control" file with content like this:
+      // +<controller1_name> +<controller2_name>
+      // (if you wish to remove a controller, prefix with `-` instead of `+`)
+      Path cgroupPath = getPath();
+      checkState(cgroupPath.startsWith("/sys/fs/cgroup/"));
+      checkState(!cgroupPath.endsWith("/"));
+      ensureControllerIsEnabled(cgroupPath, Set.of(controllerName));
     }
   }
 }

--- a/src/main/java/build/buildfarm/worker/cgroup/Group.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/Group.java
@@ -73,12 +73,10 @@ public final class Group {
         // split[1]: mountpoint
         // split[2]: fs type
         checkState(split.length >= 3, "could not parse /proc/mounts");
-        if (split[2].contains("cgroup")) {
-          if (split[2].equals("cgroup2")) {
-            return CGroupVersion.CGROUPS_V2;
-          }
+        if (split[2].equals("cgroup2")) {
+          return CGroupVersion.CGROUPS_V2;
         }
-        // by this point, we haven't found any `cgroup` or `cgroup2` fs types.
+        // by this point, we haven't found any `cgroup2` fs types.
       }
     } catch (IOException e) {
       log.log(

--- a/src/main/java/build/buildfarm/worker/cgroup/Mem.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/Mem.java
@@ -22,7 +22,7 @@ public class Mem extends Controller {
   }
 
   @Override
-  public String getName() {
+  public String getControllerName() {
     return "memory";
   }
 

--- a/src/main/java/build/buildfarm/worker/resources/CpuLimits.java
+++ b/src/main/java/build/buildfarm/worker/resources/CpuLimits.java
@@ -15,6 +15,7 @@
 package build.buildfarm.worker.resources;
 
 import java.util.ArrayList;
+import lombok.ToString;
 
 /**
  * @class CpuLimits
@@ -29,6 +30,7 @@ import java.util.ArrayList;
  *     restrictions will ultimately encourage action writers to implement their actions more
  *     efficiently or opt for local execution as an alternative.
  */
+@ToString
 public class CpuLimits {
   /**
    * @field limit

--- a/src/main/java/build/buildfarm/worker/resources/MemLimits.java
+++ b/src/main/java/build/buildfarm/worker/resources/MemLimits.java
@@ -15,6 +15,7 @@
 package build.buildfarm.worker.resources;
 
 import java.util.ArrayList;
+import lombok.ToString;
 
 /**
  * @class MemLimits
@@ -29,6 +30,7 @@ import java.util.ArrayList;
  *     ultimately encourage action writers to implement their actions more efficiently or opt for
  *     local execution as an alternative.
  */
+@ToString
 public class MemLimits {
   /**
    * @field limit

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -1081,7 +1081,7 @@ class ShardWorkerContext implements WorkerContext {
         cpu.setMaxCpu(limits.cpu.max);
       }
       if (limits.cpu.min > 0) {
-        cpu.setShares(limits.cpu.min * 1024);
+        cpu.setShares(limits.cpu.min);
       }
     } catch (IOException e) {
       // clear interrupt flag if set due to ClosedByInterruptException

--- a/src/test/java/build/buildfarm/worker/cgroup/GroupV2Test.java
+++ b/src/test/java/build/buildfarm/worker/cgroup/GroupV2Test.java
@@ -15,35 +15,32 @@
 package build.buildfarm.worker.cgroup;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Set;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+/** These test CGroups v2 behavior exclusively. */
 @RunWith(JUnit4.class)
-public class GroupTest {
+public class GroupV2Test {
+
+  @Before
+  public void setup() {
+    Group.VERSION = CGroupVersion.CGROUPS_V2;
+  }
+
   @Test
   public void testHierarchy() {
     Group g = Group.getRoot().getChild("c1");
     assertThat(g).isNotNull();
     assertThat(g.getHierarchy()).isEqualTo("c1");
     assertThat(g.getChild("c2").getHierarchy()).isEqualTo("c1/c2");
-    assertThat(g.getHierarchy("cpu")).isEqualTo("cpu/c1");
-  }
-
-  @Test
-  public void testGetPathWithControllerName() {
-    Group g = Group.getRoot().getChild("c1");
-    assertThat(g.getPath("banana")).isEqualTo(Path.of("/sys/fs/cgroup/banana/c1"));
-
-    Group g2 = g.getChild("c2");
-    assertThat(g2.getPath("apple")).isEqualTo(Path.of("/sys/fs/cgroup/apple/c1/c2"));
   }
 
   @Test
@@ -58,8 +55,8 @@ public class GroupTest {
   @Test
   public void testIsEmpty() throws IOException {
     Group mockGroup = spy(Group.getRoot().getChild("c1"));
-    when(mockGroup.getPids(anyString())).thenReturn(Set.of(7, 8, 9));
+    when(mockGroup.getPids()).thenReturn(Set.of(7, 8, 9));
 
-    assertThat(mockGroup.isEmpty("cpu")).isFalse();
+    assertThat(mockGroup.isEmpty()).isFalse();
   }
 }


### PR DESCRIPTION
Remove support for cgroups v1 and move to cgroups v2.

Not tested: 
- [ ] Windows

Outstanding before merge:
- [x] What do to for "minCpu" in cgroups v2? Shares are gone.
- [ ] should the config be renamed to `alwaysUseCgroupsv2` to specify v2?