### PR TITLE
Interpret WriteCompleteException in WSO with future

### DIFF
--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -1016,6 +1016,10 @@ public abstract class CASFileCache implements ContentAddressableStorage {
               reset();
             }
             if (isComplete()) {
+              if (!future.isDone()) {
+                log.log(Level.WARNING, format("%s isComplete but has not completed future", key));
+                future.set(key.getDigest().getSize());
+              }
               throw new WriteCompleteException();
             }
             checkState(

--- a/src/main/java/build/buildfarm/common/Write.java
+++ b/src/main/java/build/buildfarm/common/Write.java
@@ -32,6 +32,10 @@ public interface Write {
 
   boolean isComplete();
 
+  /**
+   * Implementations may throw WriteCompleteException, but as a precondition, the future must be
+   * complete.
+   */
   FeedbackOutputStream getOutput(
       long offset, long deadlineAfter, TimeUnit deadlineAfterUnits, Runnable onReadyHandler)
       throws IOException;


### PR DESCRIPTION
Prevent propagation of the WriteCompleteException to the observer response. If it is thrown by getOutput, the precondition is that the future is complete, and will eventually be handled with status.