### PR TITLE
chore: rename timeout => timeoutMillis

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -84,7 +84,7 @@ backplane:
   maxPreQueueDepth: 1000000
   priorityQueue: false
   priorityPollIntervalMillis: 100
-  timeout: 10000
+  timeoutMillis: 10000
   correlatedInvocationsIndexPrefix: CorrelatedInvocationsIndex
   maxCorrelatedInvocationsIndexTimeout: 259200
   correlatedInvocationsPrefix: CorrelatedInvocation

--- a/src/main/java/build/buildfarm/common/config/Backplane.java
+++ b/src/main/java/build/buildfarm/common/config/Backplane.java
@@ -79,7 +79,7 @@ public class Backplane {
    */
   private boolean redisAuthWithGoogleCredentials;
 
-  private int timeout = 10000; // Milliseconds
+  private int timeoutMillis = 10000; // Milliseconds
   private String[] redisNodes = {};
   private int maxAttempts = 20;
   private long priorityPollIntervalMillis = 100;

--- a/src/main/java/build/buildfarm/instance/shard/JedisClusterFactory.java
+++ b/src/main/java/build/buildfarm/instance/shard/JedisClusterFactory.java
@@ -223,8 +223,8 @@ public class JedisClusterFactory {
     Backplane backplane = configs.getBackplane();
     DefaultJedisClientConfig.Builder builder = DefaultJedisClientConfig.builder();
 
-    builder.connectionTimeoutMillis(Integer.max(2000, backplane.getTimeout()));
-    builder.socketTimeoutMillis(Integer.max(2000, backplane.getTimeout()));
+    builder.connectionTimeoutMillis(Integer.max(2000, backplane.getTimeoutMillis()));
+    builder.socketTimeoutMillis(Integer.max(2000, backplane.getTimeoutMillis()));
     builder.clientName(identifier);
 
     if (!Strings.isNullOrEmpty(backplane.getRedisUri())) {


### PR DESCRIPTION
### What 

- Rename `timeout` => `timeoutMillis` for Backplane config.
- Improve docs about `timeout` a little bit.

### Why

> Rename `timeout` => `timeoutMillis` for Backplane config

Other parameters are `xxxMillis` suffix when the parameter requires time as milliseconds. Therefore, this `timeout` parameter is also.