### PR TITLE
chore(helm): add topologySpreadConstraints param

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,5 +166,5 @@ helm install \
   --create-namespace \
   bazel-buildfarm \
   oci://ghcr.io/buildfarm/buildfarm \
-  --version "0.2.4"
+  --version "0.2.7"
 ```

--- a/kubernetes/helm-charts/buildfarm/Chart.yaml
+++ b/kubernetes/helm-charts/buildfarm/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.6
+version: 0.2.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/kubernetes/helm-charts/buildfarm/templates/server/deployment.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/server/deployment.yaml
@@ -75,6 +75,10 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.server.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.server.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/kubernetes/helm-charts/buildfarm/templates/shard-worker/statefulsets.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/shard-worker/statefulsets.yaml
@@ -94,6 +94,11 @@ spec:
         {{- tpl (toYaml .) $ | nindent 8 -}}
       {{- end }}
 
+      {{- with .Values.shardWorker.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
       {{- with .Values.shardWorker.tolerations }}
       tolerations:
         {{- tpl (toYaml .) $ | nindent 8 -}}

--- a/kubernetes/helm-charts/buildfarm/values.yaml
+++ b/kubernetes/helm-charts/buildfarm/values.yaml
@@ -15,13 +15,13 @@ config:
   prometheusPort: 9090
   backplane:
     queues:
-        - name: "cpu"
-          allowUnmatched: true
-          properties:
-            - name: "min-cores"
-              value: "*"
-            - name: "max-cores"
-              value: "*"
+      - name: "cpu"
+        allowUnmatched: true
+        properties:
+          - name: "min-cores"
+            value: "*"
+          - name: "max-cores"
+            value: "*"
   server:
     name: "shard"
     recordBesEvents: true
@@ -35,7 +35,8 @@ server:
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
   replicaCount: 1
-  resources: { }
+  resources:
+    {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -53,7 +54,7 @@ server:
   ingress:
     enabled: false
     className: ""
-    annotations: { }
+    annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
     hosts:
@@ -61,7 +62,7 @@ server:
         paths:
           - path: /
             pathType: ImplementationSpecific
-    tls: [ ]
+    tls: []
     #  - secretName: chart-example-tls
     #    hosts:
     #      - chart-example.local
@@ -70,19 +71,22 @@ server:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-  extraVolumes: []
+  topologySpreadConstraints: []
+  extraVolumes:
+    []
     # - name: additionalSecret
     #   secret:
     #   secretName: my-secret
     #   defaultMode: 0600
 
-  extraVolumeMounts: []
+  extraVolumeMounts:
+    []
     # - name: customConfig
     #   mountPath: /mnt/config
     #   readOnly: true
   extraEnv:
-  - name: JAVABIN
-    value: "/usr/bin/java"
+    - name: JAVABIN
+      value: "/usr/bin/java"
 
   serviceMonitor:
     ## If true, a ServiceMonitor CRD is created for a prometheus operator
@@ -104,7 +108,7 @@ server:
     handlers: java.util.logging.ConsoleHandler
     java.util.logging.ConsoleHandler.level: INFO
     java.util.logging.ConsoleHandler.formatter: java.util.logging.SimpleFormatter
-    java.util.logging.SimpleFormatter.format: '[%4$-7s] %2$s - %5$s %6$s %n'
+    java.util.logging.SimpleFormatter.format: "[%4$-7s] %2$s - %5$s %6$s %n"
 
 shardWorker:
   image:
@@ -119,15 +123,16 @@ shardWorker:
     maxReplicas: 4
     behavior: {} # effective only in `v2*`
     metrics: # effective only in `v2*`
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: 50
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 50
     targetCPUUtilizationPercentage: 50 # effective only in `v1`
 
-  resources: { }
+  resources:
+    {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -151,6 +156,7 @@ shardWorker:
   #nodeSelector: {}
   #tolerations: []
   #affinity: {}
+  #topologySpreadConstraints: []
 
   #extraVolumes:
   # - name: additionalSecret
@@ -164,8 +170,8 @@ shardWorker:
   #   readOnly: true
 
   extraEnv:
-  - name: JAVABIN
-    value: "/usr/bin/java"
+    - name: JAVABIN
+      value: "/usr/bin/java"
 
   serviceMonitor:
     ## If true, a ServiceMonitor CRD is created for a prometheus operator
@@ -187,7 +193,7 @@ shardWorker:
     handlers: java.util.logging.ConsoleHandler
     java.util.logging.ConsoleHandler.level: INFO
     java.util.logging.ConsoleHandler.formatter: java.util.logging.SimpleFormatter
-    java.util.logging.SimpleFormatter.format: '[%4$-7s] %2$s - %5$s %6$s %n'
+    java.util.logging.SimpleFormatter.format: "[%4$-7s] %2$s - %5$s %6$s %n"
 
 ###################################
 ## DATABASE | Embedded Redis


### PR DESCRIPTION
Missing `topologySpreadConstraints` parameter.
Bump Helm version (though I'm not sure this is the proper workflow)

I don't know if you should also change the image tag versions?