### PR TITLE
chore: Add annotation support for Server and ShardWorker in Helm charts

### DIFF
--- a/kubernetes/helm-charts/buildfarm/templates/server/deployment.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/server/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "buildfarm.labels" . | nindent 4 }}
     app.kubernetes.io/component: server
   annotations:
-    {{- toYaml .Values.shardWorker.annotations | nindent 4 }}
+    {{- toYaml .Values.server.annotations | nindent 4 }}
 spec:
   replicas: {{ .Values.server.replicaCount }}
   selector:

--- a/kubernetes/helm-charts/buildfarm/templates/server/deployment.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/server/deployment.yaml
@@ -6,6 +6,8 @@ metadata:
     name: {{ include "buildfarm.fullname" . }}-server
     {{- include "buildfarm.labels" . | nindent 4 }}
     app.kubernetes.io/component: server
+  annotations:
+    {{- toYaml .Values.shardWorker.annotations | nindent 4 }}
 spec:
   replicas: {{ .Values.server.replicaCount }}
   selector:

--- a/kubernetes/helm-charts/buildfarm/templates/shard-worker/statefulsets.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/shard-worker/statefulsets.yaml
@@ -6,6 +6,8 @@ metadata:
     name: {{ include "buildfarm.fullname" . }}-shard-worker
     {{- include "buildfarm.labels" . | nindent 4 }}
     app.kubernetes.io/component: shard-worker
+  annotations:
+    {{- toYaml .Values.shardWorker.annotations | nindent 4 }}
 spec:
   serviceName: {{ include "buildfarm.fullname" . }}-shard-worker
   {{- if .Values.shardWorker.autoscaling.enabled }}


### PR DESCRIPTION
**why:**
Add annotation support for Server and ShardWorker in Helm charts. This enables integration with Kubernetes controllers.