### PR TITLE
chore: reduce log spam for duplicate operations

### DIFF
--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -419,7 +419,7 @@ class ShardWorkerContext implements WorkerContext {
             String operationName = queueEntry.getExecuteEntry().getOperationName();
             if (activeOperations.putIfAbsent(operationName, queueEntry) != null) {
               claim.release();
-              log.log(Level.WARNING, "matched duplicate operation " + operationName);
+              log.log(Level.FINE, "matched duplicate operation " + operationName);
               return false;
             }
             return onUniqueEntry(queueEntry, claim);


### PR DESCRIPTION
This can come up a lot. Reducing to FINE.

(Curiously.. this logs a lot from the Worker but the Server's prometheus Counter for `merged_executions` doesn't grow. 🤔 )