### PR TITLE
Simplify and configurize windows-default command handling

### DIFF
--- a/src/main/java/build/buildfarm/common/BUILD
+++ b/src/main/java/build/buildfarm/common/BUILD
@@ -15,6 +15,7 @@ java_library(
     plugins = [":lombok"],
     visibility = ["//visibility:public"],
     deps = [
+        "//src/main/java/build/buildfarm/common/base",
         "//src/main/java/build/buildfarm/common/blake3",
         "//src/main/java/build/buildfarm/common/resources:resource_java_proto",
         "//src/main/protobuf/build/buildfarm/v1test:buildfarm_java_proto",

--- a/src/main/java/build/buildfarm/common/base/BUILD
+++ b/src/main/java/build/buildfarm/common/base/BUILD
@@ -1,0 +1,7 @@
+load("@rules_java//java:java_library.bzl", "java_library")
+
+java_library(
+    name = "base",
+    srcs = glob(["*.java"]),
+    visibility = ["//visibility:public"],
+)

--- a/src/main/java/build/buildfarm/common/base/System.java
+++ b/src/main/java/build/buildfarm/common/base/System.java
@@ -1,0 +1,27 @@
+// Copyright 2025 The Buildfarm Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common.base;
+
+public final class System {
+  public static boolean isDarwin() {
+    return java.lang.System.getProperty("os.name").equals("Mac OS X");
+  }
+
+  public static boolean isWindows() {
+    return java.lang.System.getProperty("os.name").startsWith("Windows");
+  }
+
+  private System() {}
+}

--- a/src/main/java/build/buildfarm/common/blake3/BUILD
+++ b/src/main/java/build/buildfarm/common/blake3/BUILD
@@ -17,6 +17,7 @@ java_library(
     }),
     visibility = ["//src/main/java/build/buildfarm/common:__pkg__"],
     deps = [
+        "//src/main/java/build/buildfarm/common/base",
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_errorprone_error_prone_annotations",
         "@maven//:com_google_guava_guava",

--- a/src/main/java/build/buildfarm/common/blake3/JniLoader.java
+++ b/src/main/java/build/buildfarm/common/blake3/JniLoader.java
@@ -14,6 +14,8 @@
 
 package build.buildfarm.common.blake3;
 
+import static build.buildfarm.common.base.System.isDarwin;
+import static build.buildfarm.common.base.System.isWindows;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.io.ByteStreams;
@@ -31,14 +33,6 @@ import lombok.extern.java.Log;
 @Log
 public final class JniLoader {
   @Nullable private static final Throwable JNI_LOAD_ERROR;
-
-  private static boolean isDarwin() {
-    return System.getProperty("os.name").equals("Mac OS X");
-  }
-
-  private static boolean isWindows() {
-    return System.getProperty("os.name").startsWith("Windows");
-  }
 
   static {
     Throwable jniLoadError;

--- a/src/main/java/build/buildfarm/common/config/BUILD
+++ b/src/main/java/build/buildfarm/common/config/BUILD
@@ -9,6 +9,7 @@ java_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/main/java/build/buildfarm/common",
+        "//src/main/java/build/buildfarm/common/base",
         "//src/main/protobuf/build/buildfarm/v1test:buildfarm_java_proto",
         "@googleapis//google/longrunning:longrunning_java_proto",
         "@googleapis//google/rpc:rpc_java_proto",

--- a/src/main/java/build/buildfarm/common/config/Worker.java
+++ b/src/main/java/build/buildfarm/common/config/Worker.java
@@ -14,6 +14,8 @@
 
 package build.buildfarm.common.config;
 
+import static build.buildfarm.common.base.System.isWindows;
+
 import build.buildfarm.v1test.WorkerType;
 import com.google.common.base.Strings;
 import java.nio.file.Files;
@@ -67,6 +69,7 @@ public class Worker {
 
   private boolean errorOperationOutputSizeExceeded = false;
   private boolean legacyDirectoryFileCache = false;
+  private boolean absolutizeCommandProgram = isWindows();
 
   public List<ExecutionPolicy> getExecutionPolicies() {
     return executionPolicies;

--- a/src/main/java/build/buildfarm/common/config/Worker.java
+++ b/src/main/java/build/buildfarm/common/config/Worker.java
@@ -1,3 +1,17 @@
+// Copyright 2025 The Buildfarm Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package build.buildfarm.common.config;
 
 import build.buildfarm.v1test.WorkerType;

--- a/src/main/java/build/buildfarm/common/io/Utils.java
+++ b/src/main/java/build/buildfarm/common/io/Utils.java
@@ -14,6 +14,8 @@
 
 package build.buildfarm.common.io;
 
+import static build.buildfarm.common.base.System.isDarwin;
+
 import com.google.common.base.Strings;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
@@ -56,15 +58,6 @@ public final class Utils {
   @SuppressWarnings("Guava")
   private static final Supplier<LibC> libc =
       Suppliers.memoize(() -> LibraryLoader.create(LibC.class).load("c"));
-
-  // pretty poor check here, but avoiding apache commons for now
-  @SuppressWarnings("Guava")
-  private static final Supplier<Boolean> isMacOS =
-      Suppliers.memoize(
-          () -> {
-            String osName = System.getProperty("os.name").toLowerCase();
-            return osName.startsWith("mac");
-          });
 
   private static jnr.ffi.Runtime runtime() {
     return jnr.ffi.Runtime.getRuntime(libc.get());
@@ -220,7 +213,7 @@ public final class Utils {
       throws IOException {
     final List<NamedFileKey> dirents;
     // OSX presents an incompatible ffi dirent structure that has not been properly enumerated
-    if (fileStore.supportsFileAttributeView("posix") && !isMacOS.get()) {
+    if (fileStore.supportsFileAttributeView("posix") && !isDarwin()) {
       dirents = ffiReaddir(libc.get(), runtime(), path, fileStore);
     } else {
       dirents = listNIOdirentSorted(path, fileStore);

--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -61,6 +61,7 @@ import com.google.rpc.Code;
 import io.grpc.Deadline;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -310,17 +311,19 @@ class Executor {
             arguments,
             executionContext.command,
             workingDirectory)) {
-      if (System.getProperty("os.name").contains("Win")) {
-        // Make sure that the executable path is absolute, otherwise processbuilder fails on windows
-        Iterator<String> argumentItr = command.getArgumentsList().iterator();
-        if (argumentItr.hasNext()) {
-          String exe = argumentItr.next(); // Get first element, this is the executable
-          arguments.add(workingDirectory.resolve(exe).toAbsolutePath().normalize().toString());
-          argumentItr.forEachRemaining(arguments::add);
-        }
-      } else {
-        arguments.addAll(command.getArgumentsList());
+      // Windows requires that relative command programs are absolutized
+      Iterator<String> argumentItr = command.getArgumentsList().iterator();
+      boolean absolutizeExe =
+          BuildfarmConfigs.getInstance().getWorker().isAbsolutizeCommandProgram()
+              && argumentItr.hasNext()
+              && Files.exists(workingDirectory.resolve(command.getArguments(0)));
+      if (absolutizeExe) {
+        Path exe =
+            workingDirectory.resolve(
+                argumentItr.next()); // Get first element, this is the executable
+        arguments.add(exe.toAbsolutePath().normalize().toString());
       }
+      argumentItr.forEachRemaining(arguments::add);
 
       statusCode =
           executeCommand(

--- a/src/main/java/build/buildfarm/worker/shard/WorkerProfileService.java
+++ b/src/main/java/build/buildfarm/worker/shard/WorkerProfileService.java
@@ -26,6 +26,7 @@ import build.buildfarm.worker.PipelineStage;
 import build.buildfarm.worker.PutOperationStage;
 import build.buildfarm.worker.PutOperationStage.OperationStageDurations;
 import build.buildfarm.worker.SuperscalarPipelineStage;
+import com.google.common.base.Strings;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import javax.annotation.Nullable;
@@ -60,7 +61,7 @@ public class WorkerProfileService extends WorkerProfileGrpc.WorkerProfileImplBas
   private StageInformation unaryStageInformation(String name, @Nullable String operationName) {
     StageInformation.Builder builder =
         StageInformation.newBuilder().setName(name).setSlotsConfigured(1);
-    if (operationName != null) {
+    if (!Strings.isNullOrEmpty(operationName)) {
       builder.setSlotsUsed(1).addOperationNames(operationName);
     }
     return builder.build();

--- a/src/test/java/build/buildfarm/common/io/BUILD
+++ b/src/test/java/build/buildfarm/common/io/BUILD
@@ -6,6 +6,7 @@ java_test(
     test_class = "build.buildfarm.AllTests",
     deps = [
         "//src/main/java/build/buildfarm/common",
+        "//src/main/java/build/buildfarm/common/base",
         "//src/main/java/build/buildfarm/common/grpc",
         "//src/test/java/build/buildfarm:test_runner",
         "@googleapis//google/bytestream:bytestream_java_grpc",

--- a/src/test/java/build/buildfarm/common/io/UtilsTest.java
+++ b/src/test/java/build/buildfarm/common/io/UtilsTest.java
@@ -14,6 +14,7 @@
 
 package build.buildfarm.common.io;
 
+import static build.buildfarm.common.base.System.isWindows;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.protobuf.ByteString;
@@ -42,7 +43,7 @@ public class UtilsTest {
   public void setUp() throws IOException {
     root = Files.createTempDirectory("native-cas-test");
     fileStore = Files.getFileStore(root);
-    org.junit.Assume.assumeFalse(System.getProperty("os.name").contains("Win"));
+    org.junit.Assume.assumeFalse(isWindows());
   }
 
   @After

--- a/src/test/java/build/buildfarm/examples/BUILD
+++ b/src/test/java/build/buildfarm/examples/BUILD
@@ -7,6 +7,7 @@ java_test(
     data = ["//examples:example_configs"],
     test_class = "build.buildfarm.AllTests",
     deps = [
+        "//src/main/java/build/buildfarm/common/base",
         "//src/main/java/build/buildfarm/common/config",
         "//src/main/protobuf/build/buildfarm/v1test:buildfarm_java_proto",
         "//src/test/java/build/buildfarm:test_runner",

--- a/src/test/java/build/buildfarm/examples/ExampleConfigsTest.java
+++ b/src/test/java/build/buildfarm/examples/ExampleConfigsTest.java
@@ -14,6 +14,8 @@
 
 package build.buildfarm.examples;
 
+import static build.buildfarm.common.base.System.isWindows;
+
 import build.buildfarm.common.config.BuildfarmConfigs;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -28,7 +30,7 @@ import org.junit.runners.JUnit4;
 public class ExampleConfigsTest {
   @Before
   public void skipWindows() {
-    org.junit.Assume.assumeFalse(System.getProperty("os.name").contains("Win"));
+    org.junit.Assume.assumeFalse(isWindows());
   }
 
   @Test


### PR DESCRIPTION
Windows requiring an absolutized path does not apply correctly to things like genrule, which will invoke a command with `cmd.exe ... <program>`. Absolutization of the command is a transform that now checks to see whether the path exists relative to the working directory, permitting both in-tree and system command invocation.
This also cleans up the iteration and pushes the os.name invariant interpretation to configs, where it can be overridden if desired.