### PR TITLE
Update docs of Sandbox settings

### DIFF
--- a/_site/docs/configuration/configuration.md
+++ b/_site/docs/configuration/configuration.md
@@ -330,14 +330,18 @@ worker:
 ```
 
 ### Sandbox Settings
+Using the sandbox can be configurable by the client via `exec_properties`. However, sometimes it is preferred to enable it via buildfarm config to prevent users from running actions outside the sandbox.
 
-| Configuration | Accepted and _Default_ Values | Description                                          |
-|---------------|-------------------------------|------------------------------------------------------|
-| alwaysUseSandbox      | boolean, _false_      | Enforce that the sandbox be used on every acion.     |
-| alwaysUseCgroups      | boolean, _true_       | Enforce that actions run under cgroups.              |
-| alwaysUseTmpFs        | boolean, _false_      | Enforce that the sandbox uses tmpfs on every acion.  |
-| selectForBlockNetwork | boolean, _false_      | `block-network` enables sandbox action execution.    |
-| selectForTmpFs        | boolean, _false_      | `tmpfs` enables sandbox action execution.            |
+| Configuration         | Accepted and _Default_ Values | Description                                                                                                                                                                                                     |
+|-----------------------|-------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| alwaysUseSandbox      | boolean, _false_              | Whether or not to always use the sandbox when running actions. It may be preferred to enforce sandbox usage than rely on client selection.                                                                      |
+| alwaysUseAsNobody     | boolean, _false_              | Whether or not to always use the as-nobody wrapper when running actions. It may be preferred to enforce this wrapper instead of relying on client selection.                                                    |
+| alwaysUseCgroups      | boolean, _true_               | Whether or not to use cgroups when sandboxing actions.  It may be preferred to enforce cgroup usage.                                                                                                            |
+| alwaysUseTmpFs        | boolean, _false_              | Whether or not to always use tmpfs when using the sandbox. It may be preferred to enforce sandbox usage than rely on client selection.                                                                          |
+| additionalWritePaths  | List of Strings, _[]_         | Additional paths the sandbox is allowed to write to. Suggestions may include: /tmp, /dev/shm                                                                                                                    |
+| tmpFsPaths            | List of Strings, _[]_         | Additional paths the sandbox uses for tmpfs. Suggestions may include: /tmp                                                                                                                                      |
+| selectForBlockNetwork | boolean, _false_              | If the action requires "block network" use the sandbox to fulfill this request. Otherwise, there may be no alternative solution and the "block network" request will be ignored / implemented differently.      |
+| selectForTmpFs        | boolean, _false_              | If the action requires "tmpfs" use the sandbox to fulfill this request.execution. Otherwise, there may be no alternative solution and the "tmpfs" request will be ignored / implemented differently.            |
 
 Example:
 
@@ -345,8 +349,11 @@ Example:
 worker:
   sandboxSettings:
     alwaysUseSandbox: true
+    alwaysUseAsNobody: false
     alwaysUseCgroups: true
     alwaysUseTmpFs: true
+    additionalWritePaths: []
+    tmpFsPaths: []
     selectForBlockNetwork: false
     selectForTmpFs: false
 ```

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -145,8 +145,11 @@ worker:
   gracefulShutdownSeconds: 0
   sandboxSettings:
     alwaysUseSandbox: false
+    alwaysUseAsNobody: false
     alwaysUseCgroups: false
     alwaysUseTmpFs: false
+    additionalWritePaths: []
+    tmpFsPaths: []
     selectForBlockNetwork: false
     selectForTmpFs: false
   createSymlinkOutputs: false


### PR DESCRIPTION
## Summary
Update docs of Sandbox settings and example usages.

## Testing Done
Run `bazelisk run src/main/java/build/buildfarm:buildfarm-shard-worker /Users/taowang/Developer/Repo/buildfarm/examples/config.yml` and the worker can start as expected.
```
Mar 23, 2025 10:07:43 PM build.buildfarm.common.config.BuildfarmConfigs loadConfigs
INFO: BuildfarmConfigs(digestFunction=SHA256, defaultActionTimeout=600, maximumActionTimeout=3600, maxEntrySizeBytes=2147483648, prometheusPort=9090, allowSymlinkTargetAbsolute=false, server=Server(instanceType=SHARD, name=shard, actionCacheReadOnly=false, bindAddress=, port=8980, grpcMetrics=GrpcMetrics(enabled=true, provideLatencyHistograms=true, latencyBuckets=[0.001, 0.01, 0.1, 1.0, 5.0, 10.0, 20.0, 40.0, 60.0, Infinity], labelsToReport=[]), casWriteTimeout=3600, bytestreamTimeout=3600, sslCertificatePath=null, sslPrivateKeyPath=null, runDispatchedMonitor=true, dispatchedMonitorIntervalSeconds=1, runFailsafeOperation=true, runOperationQueuer=true, ensureOutputsPresent=true, mergeExecutions=true, maxRequeueAttempts=5, useDenyList=true, grpcTimeout=3600, executeKeepaliveAfterSeconds=60, recordBesEvents=false, admin=Admin(deploymentEnvironment=AWS, clusterEndpoint=grpc://localhost, enableGracefulShutdown=false), metrics=Metrics(publisher=LOG, logLevel=FINEST, topic=test, topicMaxConnections=1000, secretName=test), maxCpu=0, clusterId=local, cloudRegion=us-east-1, publicName=null, maxInboundMessageSizeBytes=0, maxInboundMetadataSize=0, caches=ServerCacheConfigs(directoryCacheMaxEntries=10000, commandCacheMaxEntries=10000, digestToActionCacheMaxEntries=10000, recentServedExecutionsCacheMaxEntries=10000), findMissingBlobsViaBackplane=false, gracefulShutdownSeconds=0, correlatedInvocationsIndexScopes=[host, username]), backplane=Backplane(type=SHARD, redisUri=redis://localhost:6379, jedisPoolMaxTotal=4000, jedisPoolMaxIdle=8, jedisPoolMinIdle=0, jedisTimeBetweenEvictionRunsMillis=30000, workersHashName=Workers, workerChannel=WorkerChannel, actionCachePrefix=ActionCache, actionCacheExpire=2419200, actionBlacklistPrefix=ActionBlacklist, actionBlacklistExpire=3600, invocationBlacklistPrefix=InvocationBlacklist, operationPrefix=Operation, actionsPrefix=Action, operationExpire=604800, actionExecutionExpire=21600, preQueuedOperationsListName={Arrival}:PreQueuedOperations, processingListName={Arrival}:ProcessingOperations, processingPrefix=Processing, processingTimeoutMillis=20000, queuedOperationsListName={Execution}:QueuedOperations, dispatchingPrefix=Dispatching, dispatchingTimeoutMillis=10000, dispatchedOperationsHashName=DispatchedOperations, operationChannelPrefix=OperationChannel, casPrefix=ContentAddressableStorage, casExpire=604800, correlatedInvocationsIndexPrefix=CorrelatedInvocationsIndex, maxCorrelatedInvocationsIndexTimeout=259200, correlatedInvocationsPrefix=CorrelatedInvocation, maxCorrelatedInvocationsTimeout=604800, toolInvocationsPrefix=ToolInvocation, maxToolInvocationTimeout=604800, subscribeToBackplane=true, runFailsafeOperation=true, maxQueueDepth=100000, maxPreQueueDepth=1000000, priorityQueue=false, queues=[Queue(name=cpu, allowUnmatched=true, properties=[Property(name=min-cores, value=*), Property(name=max-cores, value=*)])], redisCredentialFile=null, redisUsername=null, redisCertificateAuthorityFile=null, redisAuthWithGoogleCredentials=false, timeout=10000, redisNodes=null, maxAttempts=20, priorityPollIntervalMillis=100), worker=Worker(port=8981, grpcMetrics=GrpcMetrics(enabled=false, provideLatencyHistograms=false, latencyBuckets=[0.001, 0.005, 0.01, 0.05, 0.075, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0], labelsToReport=null), publicName=localhost:8981, capabilities=Capabilities(cas=true, execution=true), root=/tmp/worker, inlineContentLimit=1048567, operationPollPeriod=1, dequeueMatchSettings=DequeueMatchSettings(acceptEverything=false, allowUnmatched=false, properties=[]), storages=[Cas(type=FILESYSTEM, path=cache, hexBucketLevels=0, maxSizeBytes=2147483648, fileDirectoriesIndexInMemory=false, skipLoad=false, execRootCopyFallback=false, target=null, readonly=false, publishTtlMetric=false)], executeStageWidth=1, executeStageWidthOffset=0, inputFetchStageWidth=1, inputFetchDeadline=60, reportResultStageWidth=1, linkExecFileSystem=true, linkInputDirectories=true, linkedInputDirectories=[(?!external/)[^/]+], execOwner=null, execOwners=[], defaultMaxCores=0, limitGlobalExecution=false, onlyMulticoreTests=false, allowBringYourOwnContainer=false, errorOperationRemainingResources=false, gracefulShutdownSeconds=0, executionPolicies=[ExecutionPolicy(name=test, executionWrapper=ExecutionWrapper(path=/, arguments=null))], sandboxSettings=SandboxSettings(alwaysUseSandbox=false, alwaysUseAsNobody=false, alwaysUseCgroups=false, alwaysUseTmpFs=false, additionalWritePaths=[], tmpFsPaths=[], selectForBlockNetwork=false, selectForTmpFs=false), createSymlinkOutputs=false, zstdBufferPoolSize=2048, persistentWorkerActionMnemonicAllowlist=[*], resources=[LimitedResource(type=SEMAPHORE, name=sockets, amount=4096, releaseStage=EXECUTE_ACTION_STAGE), LimitedResource(type=POOL, name=gpu, amount=4, releaseStage=EXECUTE_ACTION_STAGE)], errorOperationOutputSizeExceeded=false, legacyDirectoryFileCache=false, absolutizeCommandProgram=false), executionWrappers=ExecutionWrappers(cgroups=/usr/bin/cgexec, unshare=/usr/bin/unshare, linuxSandbox=/app/build_buildfarm/linux-sandbox, asNobody=/app/build_buildfarm/as-nobody, processWrapper=/app/build_buildfarm/process-wrapper, skipSleep=/app/build_buildfarm/skip_sleep, skipSleepPreload=/app/build_buildfarm/skip_sleep_preload.so, delay=/app/build_buildfarm/delay.sh))
Mar 23, 2025 10:07:43 PM build.buildfarm.common.config.BuildfarmConfigs lambda$checkExecutionWrapperAvailability$0
WARNING: the execution wrapper /app/build_buildfarm/skip_sleep is missing and therefore the following features will not be available: skip-sleep, time-shift
Mar 23, 2025 10:07:43 PM build.buildfarm.common.config.BuildfarmConfigs lambda$checkExecutionWrapperAvailability$0
WARNING: the execution wrapper /app/build_buildfarm/skip_sleep_preload.so is missing and therefore the following features will not be available: skip-sleep, time-shift
Mar 23, 2025 10:07:43 PM build.buildfarm.common.config.BuildfarmConfigs lambda$checkExecutionWrapperAvailability$0
WARNING: the execution wrapper /app/build_buildfarm/delay.sh is missing and therefore the following features will not be available: skip-sleep, time-shift
Mar 23, 2025 10:07:43 PM build.buildfarm.common.config.BuildfarmConfigs lambda$checkExecutionWrapperAvailability$0
WARNING: the execution wrapper /app/build_buildfarm/linux-sandbox is missing and therefore the following features will not be available: linux-sandbox, block-network, tmpfs
Mar 23, 2025 10:07:43 PM build.buildfarm.common.config.BuildfarmConfigs lambda$checkExecutionWrapperAvailability$0
WARNING: the execution wrapper /app/build_buildfarm/as-nobody is missing and therefore the following features will not be available: as-nobody
Mar 23, 2025 10:07:43 PM build.buildfarm.common.config.BuildfarmConfigs lambda$checkExecutionWrapperAvailability$0
WARNING: the execution wrapper /app/build_buildfarm/process-wrapper is missing and therefore the following features will not be available: process-wrapper
Mar 23, 2025 10:07:43 PM build.buildfarm.common.config.BuildfarmConfigs lambda$checkExecutionWrapperAvailability$0
WARNING: the execution wrapper /usr/bin/cgexec is missing and therefore the following features will not be available: limit_execution, cores, min-cores, max-cores, min-mem, max-mem
Mar 23, 2025 10:07:43 PM build.buildfarm.cas.cfc.CASFileCache start
INFO: Initializing cache at: /tmp/worker/cache
Mar 23, 2025 10:07:43 PM build.buildfarm.cas.cfc.CASFileCache logCacheScanResults
INFO: {"keys":0,"dirs":0,"delete":0}
Mar 23, 2025 10:07:43 PM build.buildfarm.cas.cfc.CASFileCache logComputeDirectoriesResults
INFO: {"invalid dirs":0}
Mar 23, 2025 10:07:43 PM build.buildfarm.cas.cfc.CASFileCache start
INFO: Startup Time: 0s
Mar 23, 2025 10:07:43 PM build.buildfarm.metrics.prometheus.PrometheusPublisher startHttpServer
INFO: Started Prometheus HTTP Server on port 9090
Mar 23, 2025 10:07:43 PM build.buildfarm.worker.shard.Worker start
INFO: buildfarm-worker-localhost:8981-eb242f21-5a22-438b-978e-da8373f66835 initialized
```