### PR TITLE
Allow for merging of base and custom config yamls

### DIFF
--- a/_site/docs/configuration/configuration.md
+++ b/_site/docs/configuration/configuration.md
@@ -5,20 +5,57 @@ nav_order: 4
 has_children: true
 ---
 
+Configuration is derived from included base configuration file located in `examples/config.yml`. This file includes sensible defaults but is not meant for production use. You can specify your own configuration file(s) by passing a comma separated list as an argument to the Buildfarm service. Please note that multiple files are allowed and will be processed in the order they are passed. Each duplicate configuration option will overwrite previous value.
+
+```
+./bazel run //src/main/java/build/buildfarm:buildfarm-server -- custom-config-server-base.yml,custom-config-server-production.yml
+```
+
+config.yml (`examples/config.yml`)
+```yaml
+server:
+  redisUri: redis://localhost:6379
+```
+
+custom-config-server-base.yml
+```yaml
+server:
+  redisUri: redis://dev:6379
+```
+
+custom-config-server-production.yml
+```yaml
+server:
+  redisUri: redis://production:6379
+```
+
+config.yml (final result)
+```yaml
+server:
+  redisUri: redis://production:6379
+```
+
 Minimal required:
 
 ```yaml
 backplane:
-  redisUri: "redis://localhost:6379"
+  redisUri: redis://localhost:6379
   queues:
-    - name: "cpu"
-      properties:
-        - name: "min-cores"
-          value: "*"
-        - name: "max-cores"
-          value: "*"
+  - name: cpu
+    allowUnmatched: true
+    properties:
+    - name: min-cores
+      value: '*'
+    - name: max-cores
+      value: '*'
 worker:
-  publicName: "localhost:8981"
+  publicName: localhost:8981
+  storages:
+  - type: FILESYSTEM
+    path: cache
+    maxSizeBytes: 2147483648   # 2 * 1024 * 1024 * 1024
+  linkedInputDirectories:
+  - (?!external/)[^/]+
 ```
 
 The configuration can be provided to the server and worker as a CLI argument or through the environment variable `CONFIG_PATH`

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -4,3 +4,8 @@ filegroup(
     name = "example_configs",
     srcs = glob(["*.yml"]),
 )
+
+filegroup(
+    name = "base_config",
+    srcs = ["config.yml"],
+)

--- a/examples/config.minimal.yml
+++ b/examples/config.minimal.yml
@@ -2,10 +2,17 @@ backplane:
   redisUri: redis://localhost:6379
   queues:
   - name: cpu
+    allowUnmatched: true
     properties:
-    - name: '*'
+    - name: min-cores
+      value: '*'
+    - name: max-cores
       value: '*'
 worker:
   publicName: localhost:8981
-  dequeueMatchSettings:
-    allowUnmatched: true
+  storages:
+  - type: FILESYSTEM
+    path: cache
+    maxSizeBytes: 2147483648   # 2 * 1024 * 1024 * 1024
+  linkedInputDirectories:
+  - (?!external/)[^/]+

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -11,8 +11,8 @@ server:
   port: 8980
   bindAddress: ''
   grpcMetrics:
-    enabled: true
-    provideLatencyHistograms: true
+    enabled: false
+    provideLatencyHistograms: false
     latencyBuckets: [0.001, 0.01, 0.1, 1, 5, 10, 20, 40, 60, +Infinity]
     labelsToReport: []
   maxInboundMessageSizeBytes: 0
@@ -28,12 +28,12 @@ server:
   mergeExecutions: true
   runFailsafeOperation: true
   maxCpu: 0
-  maxRequeueAttempts: 5
+  maxRequeueAttempts: 3
   useDenyList: true
   grpcTimeout: 3600
   executeKeepaliveAfterSeconds: 60
   recordBesEvents: false
-  clusterId: local
+  clusterId: ''
   cloudRegion: us-east-1
   gracefulShutdownSeconds: 0
   caches:
@@ -59,12 +59,13 @@ backplane:
   redisUsername:
   redisPassword:
   redisNodes:
-  jedisPoolMaxTotal: 4000
+  jedisPoolMaxTotal: 100
   jedisPoolMaxIdle: 8
   jedisPoolMinIdle: 0
   jedisTimeBetweenEvictionRunsMillis: 30000
   workersHashName: Workers
   workerChannel: WorkerChannel
+  actionExecutionExpire: 21600 # 6 Hours
   actionCachePrefix: ActionCache
   actionCacheExpire: 2419200 # 4 weeks
   actionBlacklistPrefix: ActionBlacklist
@@ -92,16 +93,10 @@ backplane:
   maxCorrelatedInvocationsIndexTimeout: 259200
   correlatedInvocationsPrefix: CorrelatedInvocation
   maxCorrelatedInvocationsTimeout: 604800
+  toolInvocationsPrefix: ToolInvocation
   maxToolInvocationTimeout: 604800
   maxAttempts: 20
   queues:
-  - name: cpu
-    allowUnmatched: true
-    properties:
-    - name: min-cores
-      value: '*'
-    - name: max-cores
-      value: '*'
 worker:
   port: 8981
   publicName: localhost:8981
@@ -118,15 +113,6 @@ worker:
   dequeueMatchSettings:
     allowUnmatched: false
   storages:
-  - type: FILESYSTEM
-    path: cache
-    maxSizeBytes: 2147483648   # 2 * 1024 * 1024 * 1024
-    fileDirectoriesIndexInMemory: false
-    skipLoad: false
-    hexBucketLevels: 0
-    execRootCopyFallback: false
-    #- type: GRPC
-    #  target: "grpc://host:port"
   executeStageWidth: 1
   inputFetchStageWidth: 1
   inputFetchDeadline: 60
@@ -134,7 +120,6 @@ worker:
   linkExecFileSystem: true
   linkInputDirectories: true
   linkedInputDirectories:
-  - (?!external/)[^/]+
   execOwner:
   defaultMaxCores: 0
   limitGlobalExecution: false
@@ -155,18 +140,7 @@ worker:
   createSymlinkOutputs: false
   zstdBufferPoolSize: 2048
   executionPolicies:
-  - name: test
-    executionWrapper:
-      path: /
-      arguments:
-  resources:
-  - name: sockets
-    amount: 4096
-  - name: gpu
-    type: POOL
-    amount: 4 # for an A30 MiG in full splay
   persistentWorkerActionMnemonicAllowlist:
-  - '*'
 executionWrappers:
   cgroups: /usr/bin/cgexec
   unshare: /usr/bin/unshare

--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -13,8 +13,9 @@ filegroup(
 
 java_binary(
     name = "buildfarm-server",
-    classpath_resources = [
+    data = [
         ":configs",
+        "//examples:base_config",
     ],
     jvm_flags = ensure_accurate_metadata() + add_opens_sun_nio_fs(),
     main_class = "build.buildfarm.server.BuildFarmServer",
@@ -27,8 +28,9 @@ java_binary(
 
 java_binary(
     name = "buildfarm-shard-worker",
-    classpath_resources = [
+    data = [
         ":configs",
+        "//examples:base_config",
     ],
     jvm_flags = ensure_accurate_metadata() + add_opens_sun_nio_fs(),
     main_class = "build.buildfarm.worker.shard.Worker",

--- a/src/main/java/build/buildfarm/common/config/Admin.java
+++ b/src/main/java/build/buildfarm/common/config/Admin.java
@@ -11,7 +11,4 @@ public class Admin {
 
   private DEPLOYMENT_ENVIRONMENT deploymentEnvironment;
   private String clusterEndpoint;
-  // This configuration is deprecated but is left here for backwards compatibility. Use
-  // worker:gracefulShutdownSeconds instead.
-  private boolean enableGracefulShutdown;
 }

--- a/src/main/java/build/buildfarm/common/config/Backplane.java
+++ b/src/main/java/build/buildfarm/common/config/Backplane.java
@@ -3,9 +3,7 @@ package build.buildfarm.common.config;
 import com.google.common.base.Strings;
 import java.net.URI;
 import javax.annotation.Nullable;
-import lombok.AccessLevel;
 import lombok.Data;
-import lombok.Getter;
 import lombok.ToString;
 import oshi.util.FileUtil;
 import redis.clients.jedis.util.JedisURIHelper;
@@ -16,50 +14,43 @@ public class Backplane {
     SHARD
   }
 
-  private BACKPLANE_TYPE type = BACKPLANE_TYPE.SHARD;
+  private BACKPLANE_TYPE type;
   private String redisUri;
-  private int jedisPoolMaxTotal = 4000;
-  private int jedisPoolMaxIdle = 8;
-  private int jedisPoolMinIdle = 0;
-  private long jedisTimeBetweenEvictionRunsMillis = 30000L;
-  private String workersHashName = "Workers";
-  private String workerChannel = "WorkerChannel";
-  private String actionCachePrefix = "ActionCache";
-  private int actionCacheExpire = 2419200; // 4 Weeks
-  private String actionBlacklistPrefix = "ActionBlacklist";
-  private int actionBlacklistExpire = 3600; // 1 Hour;
-  private String invocationBlacklistPrefix = "InvocationBlacklist";
-  private String operationPrefix = "Operation";
-  private String actionsPrefix = "Action";
-  private int operationExpire = 604800; // 1 Week
-  private int actionExecutionExpire = 21600; // 6 Hours
-  private String preQueuedOperationsListName = "{Arrival}:PreQueuedOperations";
-  private String processingListName = "{Arrival}:ProcessingOperations";
-  private String processingPrefix = "Processing";
-  private int processingTimeoutMillis = 20000;
-  private String queuedOperationsListName = "{Execution}:QueuedOperations";
-  private String dispatchingPrefix = "Dispatching";
-  private int dispatchingTimeoutMillis = 10000;
-  private String dispatchedOperationsHashName = "DispatchedOperations";
-  private String operationChannelPrefix = "OperationChannel";
-  private String casPrefix = "ContentAddressableStorage";
-  private int casExpire = 604800; // 1 Week
-  private String correlatedInvocationsIndexPrefix = "CorrelatedInvocationsIndex";
-  private int maxCorrelatedInvocationsIndexTimeout = 3 * 24 * 60 * 60; // 3 Days
-  private String correlatedInvocationsPrefix = "CorrelatedInvocations";
-  private int maxCorrelatedInvocationsTimeout = 7 * 24 * 60 * 60; // 1 Week
-  private String toolInvocationsPrefix = "ToolInvocation";
-  private int maxToolInvocationTimeout = 604800;
-
-  @Getter(AccessLevel.NONE)
-  private boolean subscribeToBackplane = true; // deprecated
-
-  @Getter(AccessLevel.NONE)
-  private boolean runFailsafeOperation = true; // deprecated
-
-  private int maxQueueDepth = 100000;
-  private int maxPreQueueDepth = 1000000;
-  private boolean priorityQueue = false;
+  private int jedisPoolMaxTotal;
+  private int jedisPoolMaxIdle;
+  private int jedisPoolMinIdle;
+  private long jedisTimeBetweenEvictionRunsMillis;
+  private String workersHashName;
+  private String workerChannel;
+  private String actionCachePrefix;
+  private int actionCacheExpire;
+  private String actionBlacklistPrefix;
+  private int actionBlacklistExpire;
+  private String invocationBlacklistPrefix;
+  private String operationPrefix;
+  private String actionsPrefix;
+  private int operationExpire;
+  private int actionExecutionExpire;
+  private String preQueuedOperationsListName;
+  private String processingListName;
+  private String processingPrefix;
+  private int processingTimeoutMillis;
+  private String queuedOperationsListName;
+  private String dispatchingPrefix;
+  private int dispatchingTimeoutMillis;
+  private String dispatchedOperationsHashName;
+  private String operationChannelPrefix;
+  private String casPrefix;
+  private int casExpire;
+  private String correlatedInvocationsIndexPrefix;
+  private int maxCorrelatedInvocationsIndexTimeout;
+  private String correlatedInvocationsPrefix;
+  private int maxCorrelatedInvocationsTimeout;
+  private String toolInvocationsPrefix;
+  private int maxToolInvocationTimeout;
+  private int maxQueueDepth;
+  private int maxPreQueueDepth;
+  private boolean priorityQueue;
   private Queue[] queues = {};
   private String redisCredentialFile;
   private String redisUsername;
@@ -82,10 +73,10 @@ public class Backplane {
    */
   private boolean redisAuthWithGoogleCredentials;
 
-  private int timeout = 10000; // Milliseconds
+  private int timeout;
   private String[] redisNodes = {};
-  private int maxAttempts = 20;
-  private long priorityPollIntervalMillis = 100;
+  private int maxAttempts;
+  private long priorityPollIntervalMillis;
 
   /**
    * This function is used to print the URI in logs.

--- a/src/main/java/build/buildfarm/common/config/Capabilities.java
+++ b/src/main/java/build/buildfarm/common/config/Capabilities.java
@@ -4,6 +4,6 @@ import lombok.Data;
 
 @Data
 public class Capabilities {
-  private boolean cas = true;
-  private boolean execution = true;
+  private boolean cas;
+  private boolean execution;
 }

--- a/src/main/java/build/buildfarm/common/config/Cas.java
+++ b/src/main/java/build/buildfarm/common/config/Cas.java
@@ -3,9 +3,7 @@ package build.buildfarm.common.config;
 import com.google.common.base.Strings;
 import java.nio.file.Path;
 import javax.naming.ConfigurationException;
-import lombok.AccessLevel;
 import lombok.Data;
-import lombok.Getter;
 
 @Data
 public class Cas {
@@ -16,24 +14,21 @@ public class Cas {
     FUSE
   }
 
-  private TYPE type = TYPE.FILESYSTEM;
+  private TYPE type;
 
   // MEMORY/FILESYSTEM
-  private String path = "cache";
-  private int hexBucketLevels = 0;
-  private long maxSizeBytes = 0;
-  private boolean fileDirectoriesIndexInMemory = false;
-  private boolean skipLoad = false;
+  private String path;
+  private int hexBucketLevels;
+  private long maxSizeBytes;
+  private boolean fileDirectoriesIndexInMemory;
+  private boolean skipLoad;
 
   // if creating a hardlink fails, copy the file instead
-  private boolean execRootCopyFallback = false;
+  private boolean execRootCopyFallback;
 
   // GRPC
   private String target;
-  private boolean readonly = false;
-
-  @Getter(AccessLevel.NONE)
-  private boolean publishTtlMetric = false; // deprecated
+  private boolean readonly;
 
   public Path getValidPath(Path root) throws ConfigurationException {
     if (Strings.isNullOrEmpty(path)) {

--- a/src/main/java/build/buildfarm/common/config/DequeueMatchSettings.java
+++ b/src/main/java/build/buildfarm/common/config/DequeueMatchSettings.java
@@ -3,16 +3,11 @@ package build.buildfarm.common.config;
 import build.bazel.remote.execution.v2.Platform;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AccessLevel;
 import lombok.Data;
-import lombok.Getter;
 
 @Data
 public class DequeueMatchSettings {
-  @Getter(AccessLevel.NONE)
-  private boolean acceptEverything; // deprecated
-
-  private boolean allowUnmatched = false;
+  private boolean allowUnmatched;
   private List<Property> properties = new ArrayList<>();
 
   public Platform getPlatform() {

--- a/src/main/java/build/buildfarm/common/config/ExecutionWrappers.java
+++ b/src/main/java/build/buildfarm/common/config/ExecutionWrappers.java
@@ -30,21 +30,21 @@ public class ExecutionWrappers {
    * @brief The program to use when running actions under cgroups.
    * @details This program is expected to be packaged with the worker image.
    */
-  private String cgroups = "/usr/bin/cgexec";
+  private String cgroups;
 
   /**
    * @field unshare
    * @brief The program to use when desiring to unshare namespaces from the action.
    * @details This program is expected to be packaged with the worker image.
    */
-  private String unshare = "/usr/bin/unshare";
+  private String unshare;
 
   /**
    * @field linuxSandbox
    * @brief The program to use when running actions under bazel's sandbox.
    * @details This program is expected to be packaged with the worker image.
    */
-  private String linuxSandbox = "/app/build_buildfarm/linux-sandbox";
+  private String linuxSandbox;
 
   /**
    * @field asNobody
@@ -52,28 +52,28 @@ public class ExecutionWrappers {
    * @details This program is expected to be packaged with the worker image. The linux-sandbox is
    *     also capable of doing what this standalone programs does and may be chosen instead.
    */
-  private String asNobody = "/app/build_buildfarm/as-nobody";
+  private String asNobody;
 
   /**
    * @field processWrapper
    * @brief The program to use when running actions under bazel's process-wrapper
    * @details This program is expected to be packaged with the worker image.
    */
-  private String processWrapper = "/app/build_buildfarm/process-wrapper";
+  private String processWrapper;
 
   /**
    * @field skipSleep
    * @brief The program to use when running actions under bazel's skip sleep wrapper.
    * @details This program is expected to be packaged with the worker image.
    */
-  private String skipSleep = "/app/build_buildfarm/skip_sleep";
+  private String skipSleep;
 
   /**
    * @field skipSleepPreload
    * @brief The shared object that the skip sleep wrapper uses to spoof syscalls.
    * @details The shared object needs passed to the program which will LD_PRELOAD it.
    */
-  private String skipSleepPreload = "/app/build_buildfarm/skip_sleep_preload.so";
+  private String skipSleepPreload;
 
   /**
    * @field delay
@@ -81,5 +81,5 @@ public class ExecutionWrappers {
    * @details This program is expected to be packaged with the worker image. Warning: This wrapper
    *     is only intended to be used with skip_sleep.
    */
-  private String delay = "/app/build_buildfarm/delay.sh";
+  private String delay;
 }

--- a/src/main/java/build/buildfarm/common/config/GrpcMetrics.java
+++ b/src/main/java/build/buildfarm/common/config/GrpcMetrics.java
@@ -8,8 +8,8 @@ import me.dinowernli.grpc.prometheus.MonitoringServerInterceptor;
 
 @Data
 public class GrpcMetrics {
-  private boolean enabled = false;
-  private boolean provideLatencyHistograms = false;
+  private boolean enabled;
+  private boolean provideLatencyHistograms;
   private double[] latencyBuckets;
   private List<String> labelsToReport;
 

--- a/src/main/java/build/buildfarm/common/config/Metrics.java
+++ b/src/main/java/build/buildfarm/common/config/Metrics.java
@@ -22,9 +22,9 @@ public class Metrics {
   }
 
   @Getter(AccessLevel.NONE)
-  private PUBLISHER publisher = PUBLISHER.LOG; // deprecated
+  private PUBLISHER publisher;
 
-  private LOG_LEVEL logLevel = LOG_LEVEL.FINEST;
+  private LOG_LEVEL logLevel;
   private String topic;
   private int topicMaxConnections;
   private String secretName;

--- a/src/main/java/build/buildfarm/common/config/Queue.java
+++ b/src/main/java/build/buildfarm/common/config/Queue.java
@@ -13,7 +13,7 @@ public class Queue {
   }
 
   private String name;
-  private boolean allowUnmatched = true;
+  private boolean allowUnmatched;
   private List<Property> properties = new ArrayList<>();
 
   public Platform getPlatform() {

--- a/src/main/java/build/buildfarm/common/config/SandboxSettings.java
+++ b/src/main/java/build/buildfarm/common/config/SandboxSettings.java
@@ -32,28 +32,28 @@ public class SandboxSettings {
    * @brief Whether or not to always use the sandbox when running actions.
    * @details It may be preferred to enforce sandbox usage than rely on client selection.
    */
-  private boolean alwaysUseSandbox = false;
+  private boolean alwaysUseSandbox;
 
   /**
    * @field alwaysUseAsNobody
    * @brief Whether or not to always use the as-nobody wrapper when running actions.
    * @details It may be preferred to enforce this wrapper instead of relying on client selection.
    */
-  private boolean alwaysUseAsNobody = false;
+  private boolean alwaysUseAsNobody;
 
   /**
    * @field alwaysUseCgroups
    * @brief Whether or not to use cgroups when sandboxing actions.
    * @details It may be preferred to enforce cgroup usage.
    */
-  private boolean alwaysUseCgroups = true;
+  private boolean alwaysUseCgroups;
 
   /**
    * @field alwaysUseTmpFs
    * @brief Whether or not to always use tmpfs when using the sandbox.
    * @details It may be preferred to enforce sandbox usage than rely on client selection.
    */
-  private boolean alwaysUseTmpFs = false;
+  private boolean alwaysUseTmpFs;
 
   /**
    * @field additionalWritePaths
@@ -75,7 +75,7 @@ public class SandboxSettings {
    * @details Otherwise, there may be no alternative solution and the "block network" request will
    *     be ignored / implemented differently.
    */
-  private boolean selectForBlockNetwork = false;
+  private boolean selectForBlockNetwork;
 
   /**
    * @field selectForTmpFs
@@ -83,5 +83,5 @@ public class SandboxSettings {
    * @details Otherwise, there may be no alternative solution and the "tmpfs" request will be
    *     ignored / implemented differently.
    */
-  private boolean selectForTmpFs = false;
+  private boolean selectForTmpFs;
 }

--- a/src/main/java/build/buildfarm/common/config/Server.java
+++ b/src/main/java/build/buildfarm/common/config/Server.java
@@ -1,6 +1,5 @@
 package build.buildfarm.common.config;
 
-import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 import java.util.UUID;
 import lombok.Data;
@@ -15,39 +14,39 @@ public class Server {
 
   private static UUID sessionGuid = UUID.randomUUID();
 
-  private INSTANCE_TYPE instanceType = INSTANCE_TYPE.SHARD;
-  private String name = "shard";
-  private boolean actionCacheReadOnly = false;
-  private String bindAddress = "";
-  private int port = 8980;
+  private INSTANCE_TYPE instanceType;
+  private String name;
+  private boolean actionCacheReadOnly;
+  private String bindAddress;
+  private int port;
   private GrpcMetrics grpcMetrics = new GrpcMetrics();
-  private int casWriteTimeout = 3600;
-  private int bytestreamTimeout = 3600;
-  private String sslCertificatePath = null;
-  private String sslPrivateKeyPath = null;
-  private boolean runDispatchedMonitor = true;
-  private int dispatchedMonitorIntervalSeconds = 1;
-  private boolean runFailsafeOperation = true;
-  private boolean runOperationQueuer = true;
-  private boolean ensureOutputsPresent = true;
-  private boolean mergeExecutions = true;
-  private int maxRequeueAttempts = 5;
-  private boolean useDenyList = true;
-  private long grpcTimeout = 3600;
-  private long executeKeepaliveAfterSeconds = 60;
-  private boolean recordBesEvents = false;
+  private int casWriteTimeout;
+  private int bytestreamTimeout;
+  private String sslCertificatePath;
+  private String sslPrivateKeyPath;
+  private boolean runDispatchedMonitor;
+  private int dispatchedMonitorIntervalSeconds;
+  private boolean runFailsafeOperation;
+  private boolean runOperationQueuer;
+  private boolean ensureOutputsPresent;
+  private boolean mergeExecutions;
+  private int maxRequeueAttempts;
+  private boolean useDenyList;
+  private long grpcTimeout;
+  private long executeKeepaliveAfterSeconds;
+  private boolean recordBesEvents;
   private Admin admin = new Admin();
   private Metrics metrics = new Metrics();
   private int maxCpu;
-  private String clusterId = "";
+  private String clusterId;
   private String cloudRegion;
   private String publicName;
-  private int maxInboundMessageSizeBytes = 0;
-  private int maxInboundMetadataSize = 0;
+  private int maxInboundMessageSizeBytes;
+  private int maxInboundMetadataSize;
   private ServerCacheConfigs caches = new ServerCacheConfigs();
-  private boolean findMissingBlobsViaBackplane = false;
-  private int gracefulShutdownSeconds = 0;
-  private Set<String> correlatedInvocationsIndexScopes = ImmutableSet.of("host", "username");
+  private boolean findMissingBlobsViaBackplane;
+  private int gracefulShutdownSeconds;
+  private Set<String> correlatedInvocationsIndexScopes;
 
   public String getSession() {
     return String.format("buildfarm-server-%s-%s", getPublicName(), sessionGuid);

--- a/src/main/java/build/buildfarm/common/config/ServerCacheConfigs.java
+++ b/src/main/java/build/buildfarm/common/config/ServerCacheConfigs.java
@@ -30,26 +30,26 @@ public class ServerCacheConfigs {
    * @brief The max number of entries that the directory cache will hold.
    * @details This will not dictate the max memory used.
    */
-  private long directoryCacheMaxEntries = 64 * 1024;
+  private long directoryCacheMaxEntries;
 
   /**
    * @field commandCacheMaxEntries
    * @brief The max number of entries that the command cache will hold.
    * @details This will not dictate the max memory used.
    */
-  private long commandCacheMaxEntries = 64 * 1024;
+  private long commandCacheMaxEntries;
 
   /**
    * @field digestToActionCacheMaxEntries
    * @brief The max number of entries that the digest-to-action cache will hold.
    * @details This will not dictate the max memory used.
    */
-  private long digestToActionCacheMaxEntries = 64 * 1024;
+  private long digestToActionCacheMaxEntries;
 
   /**
    * @field recentServedExecutionsCacheMaxEntries
    * @brief The max number of entries that the executions cache will hold.
    * @details This will not dictate the max memory used.
    */
-  private long recentServedExecutionsCacheMaxEntries = 64 * 1024;
+  private long recentServedExecutionsCacheMaxEntries;
 }

--- a/src/main/java/build/buildfarm/common/config/Worker.java
+++ b/src/main/java/build/buildfarm/common/config/Worker.java
@@ -32,42 +32,42 @@ import lombok.extern.java.Log;
 @Data
 @Log
 public class Worker {
-  private int port = 8981;
+  private int port;
   private GrpcMetrics grpcMetrics = new GrpcMetrics();
   private String publicName;
   private Capabilities capabilities = new Capabilities();
-  private String root = "/tmp/worker";
-  private int inlineContentLimit = 1048567; // 1024 * 1024
-  private long operationPollPeriod = 1;
+  private String root;
+  private int inlineContentLimit;
+  private long operationPollPeriod;
   private DequeueMatchSettings dequeueMatchSettings = new DequeueMatchSettings();
   private List<Cas> storages = Arrays.asList(new Cas());
-  private int executeStageWidth = 0;
-  private int executeStageWidthOffset = 0;
-  private int inputFetchStageWidth = 0;
-  private int inputFetchDeadline = 60;
-  private int reportResultStageWidth = 1;
-  private boolean linkExecFileSystem = true;
-  private boolean linkInputDirectories = true;
-  private List<String> linkedInputDirectories = Arrays.asList("(?!external/)[^/]+");
+  private int executeStageWidth;
+  private int executeStageWidthOffset;
+  private int inputFetchStageWidth;
+  private int inputFetchDeadline;
+  private int reportResultStageWidth;
+  private boolean linkExecFileSystem;
+  private boolean linkInputDirectories;
+  private List<String> linkedInputDirectories;
   private String execOwner;
   private List<String> execOwners = new ArrayList<>();
-  private int defaultMaxCores = 0;
-  private boolean limitGlobalExecution = false;
-  private boolean onlyMulticoreTests = false;
-  private boolean allowBringYourOwnContainer = false;
-  private boolean errorOperationRemainingResources = false;
-  private int gracefulShutdownSeconds = 0;
+  private int defaultMaxCores;
+  private boolean limitGlobalExecution;
+  private boolean onlyMulticoreTests;
+  private boolean allowBringYourOwnContainer;
+  private boolean errorOperationRemainingResources;
+  private int gracefulShutdownSeconds;
   private List<ExecutionPolicy> executionPolicies = Collections.emptyList();
   private SandboxSettings sandboxSettings = new SandboxSettings();
-  private boolean createSymlinkOutputs = false;
-  private int zstdBufferPoolSize = 2048; /* * ZSTD_DStreamInSize (current is 128k) == 256MiB */
-  private Set<String> persistentWorkerActionMnemonicAllowlist = Set.of("*");
+  private boolean createSymlinkOutputs;
+  private int zstdBufferPoolSize;
+  private Set<String> persistentWorkerActionMnemonicAllowlist;
   // These limited resources are only for the individual worker.
   // An example would be hardware resources such as GPUs.
   // If you want GPU actions to run exclusively, define a single GPU resource.
   private List<LimitedResource> resources = new ArrayList<>();
 
-  private boolean errorOperationOutputSizeExceeded = false;
+  private boolean errorOperationOutputSizeExceeded;
   private boolean legacyDirectoryFileCache = false;
   private boolean absolutizeCommandProgram = isWindows();
 

--- a/src/main/java/build/buildfarm/worker/ExecutionPolicies.java
+++ b/src/main/java/build/buildfarm/worker/ExecutionPolicies.java
@@ -56,13 +56,15 @@ public final class ExecutionPolicies {
 
   public static Platform getMatchPlatform(Platform platform, Iterable<ExecutionPolicy> policies) {
     Platform.Builder builder = platform.toBuilder();
-    for (ExecutionPolicy policy : policies) {
-      String name = policy.getName();
-      if (!name.equals(DEFAULT_EXECUTION_POLICY_NAME)) {
-        builder
-            .addPropertiesBuilder()
-            .setName(EXECUTION_POLICY_PROPERTY_NAME)
-            .setValue(policy.getName());
+    if (policies != null) {
+      for (ExecutionPolicy policy : policies) {
+        String name = policy.getName();
+        if (!name.equals(DEFAULT_EXECUTION_POLICY_NAME)) {
+          builder
+              .addPropertiesBuilder()
+              .setName(EXECUTION_POLICY_PROPERTY_NAME)
+              .setValue(policy.getName());
+        }
       }
     }
     return builder.build();

--- a/src/test/java/build/buildfarm/examples/ExampleConfigsTest.java
+++ b/src/test/java/build/buildfarm/examples/ExampleConfigsTest.java
@@ -38,13 +38,13 @@ public class ExampleConfigsTest {
     Path configPath =
         Path.of(System.getenv("TEST_SRCDIR"), "_main", "examples", "config.minimal.yml");
     BuildfarmConfigs configs = BuildfarmConfigs.getInstance();
-    configs.loadConfigs(configPath);
+    configs.loadConfigs(configPath.toString());
   }
 
   @Test
   public void fullConfig() throws IOException {
     Path configPath = Path.of(System.getenv("TEST_SRCDIR"), "_main", "examples", "config.yml");
     BuildfarmConfigs configs = BuildfarmConfigs.getInstance();
-    configs.loadConfigs(configPath);
+    configs.loadConfigs(configPath.toString());
   }
 }

--- a/src/test/java/build/buildfarm/worker/shard/ShardWorkerContextTest.java
+++ b/src/test/java/build/buildfarm/worker/shard/ShardWorkerContextTest.java
@@ -152,7 +152,6 @@ public class ShardWorkerContextTest {
 
   @Test
   public void dequeueMatchSettingsPlatformRejectsInvalidQueueEntry() throws Exception {
-    configs.getWorker().getDequeueMatchSettings().setAcceptEverything(false);
     configs.getWorker().getDequeueMatchSettings().setAllowUnmatched(false);
     WorkerContext context = createTestContext();
     Platform matchPlatform =
@@ -170,7 +169,6 @@ public class ShardWorkerContextTest {
 
   @Test
   public void dequeueMatchSettingsPlatformAcceptsValidQueueEntry() throws Exception {
-    configs.getWorker().getDequeueMatchSettings().setAcceptEverything(false);
     configs.getWorker().getDequeueMatchSettings().setAllowUnmatched(false);
     Platform testOSPlatform =
         Platform.newBuilder()


### PR DESCRIPTION
Currently, we have defaults specified in the examples/config.yml as well as java objects. This increases likelyhood of things becoming out of sync as it currently is the case. Additionally There is no way to currently overlay multiple yaml configs on top of each other. This PR addresses both of these issues by adding the ability to overlay user specified yaml file on top of a single source of truth config.yml.

One of the main benefits here will be easier CI orchestration by allowing for a simpler way to generate configuration for each type (server/workers) and different environments.

Multiple config files are allowed as a comma separated list.