### PR TITLE
Ignore abspath test env directories

### DIFF
--- a/src/main/java/build/buildfarm/worker/OutputDirectory.java
+++ b/src/main/java/build/buildfarm/worker/OutputDirectory.java
@@ -92,7 +92,10 @@ public class OutputDirectory {
     ImmutableList.Builder<OutputDirectoryEntry> entries = ImmutableList.builder();
     for (EnvironmentVariable envVar : envVars) {
       if (OUTPUT_DIRECTORY_ENV_VARS.contains(envVar.getName())) {
-        entries.add(new OutputDirectoryEntry("/" + envVar.getValue() + "/", false));
+        String value = envVar.getValue();
+        if (!value.startsWith("/")) {
+          entries.add(new OutputDirectoryEntry("/" + value + "/", false));
+        }
       } else if (OUTPUT_FILE_ENV_VARS.contains(envVar.getName())) {
         String file = envVar.getValue();
         entries.add(


### PR DESCRIPTION
Prevent the consideration of an absolute path value for test env vars implying directories as an OutputDirectory. Bazel at least specifies TEST_TMPDIR per the test encyclopedia as existing under a --test_tmpdir prefix, undeterred by remote execution, and must not have a directory created for it under the exec root.

Related to #1208 