### PR TITLE
unmerge NOT_FOUND executions

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -1287,7 +1287,7 @@ public class RedisShardBackplane implements Backplane {
 
   @SuppressWarnings("ConstantConditions")
   @Override
-  public Operation mergeExecution(ActionKey actionKey) throws IOException {
+  public @Nullable Operation mergeExecution(ActionKey actionKey) throws IOException {
     return client.call(jedis -> state.executions.merge(jedis, actionKey.toString()));
   }
 

--- a/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
@@ -2219,6 +2219,17 @@ public class ServerInstance extends NodeInstance {
           }
         }
         execution = stripExecution(execution);
+      } else {
+        try {
+          backplane.unmergeExecution(actionKey);
+        } catch (IOException e) {
+          log.log(
+              Level.SEVERE,
+              format(
+                  "error unmerging null execution of %s",
+                  DigestUtil.toString(actionKey.getDigest())),
+              e);
+        }
       }
       watcher.observe(execution);
     }
@@ -2251,7 +2262,7 @@ public class ServerInstance extends NodeInstance {
     }
   }
 
-  private Operation validateMergedExecution(Operation execution, ActionKey actionKey)
+  private Operation validateMergedExecution(@Nullable Operation execution, ActionKey actionKey)
       throws IOException {
     if (execution == null) {
       return null;


### PR DESCRIPTION
An execution lost in the course of processing should be considered unmergeable. Removing it should stabilize server shutdowns during CACHE_CHECK, as well as other states.