### PR TITLE
Synchronize computeDirectory decrementReference

### DIFF
--- a/src/main/java/build/buildfarm/cas/cfc/DirectoryEntryCFC.java
+++ b/src/main/java/build/buildfarm/cas/cfc/DirectoryEntryCFC.java
@@ -126,8 +126,10 @@ public class DirectoryEntryCFC extends CASFileCache {
         }
       } else {
         storage.put(key, e);
-        if (e.decrementReference(header)) {
-          unreferencedEntryCount++;
+        synchronized (this) {
+          if (e.decrementReference(header)) {
+            unreferencedEntryCount++;
+          }
         }
         sizeInBytes += e.size;
       }


### PR DESCRIPTION
Failure to synchronize results in malformed LRU list accounting.