### PR TITLE
Return persistent worker action output streams even when actions have missing outputs

### DIFF
--- a/src/main/java/build/buildfarm/worker/persistent/ProtoCoordinator.java
+++ b/src/main/java/build/buildfarm/worker/persistent/ProtoCoordinator.java
@@ -231,8 +231,11 @@ public class ProtoCoordinator extends WorkCoordinator<RequestCtx, ResponseCtx, C
     for (String relOutput : context.outputFiles) {
       Path execOutputPath = workerExecRoot.resolve(relOutput);
       Path opOutputPath = opRoot.resolve(relOutput);
-
-      FileAccessUtils.moveFile(execOutputPath, opOutputPath);
+      // Don't fail here if the action failed to produce a file.
+      // The missing file will be handled just like it is for non-worker actions.
+      if (Files.exists(execOutputPath)) {
+        FileAccessUtils.moveFile(execOutputPath, opOutputPath);
+      }
     }
   }
 


### PR DESCRIPTION
The error path here would swallow the output streams and send back a [different error message](https://github.com/buildfarm/buildfarm/blob/main/src/main/java/build/buildfarm/worker/persistent/ProtoCoordinator.java#L196-L203).