### PR TITLE
fix(config): prevent NPE when no parent config directory

### DIFF
--- a/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
+++ b/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
@@ -88,6 +88,18 @@ public final class BuildfarmConfigs {
   }
 
   public static BuildfarmConfigs loadConfigs(Path configLocation) throws IOException {
+    Path parent = configLocation.getParent();
+    if (parent == null || !Files.isDirectory(parent)) {
+      log.info("Loading configs from single file: " + configLocation);
+      Yaml yaml = new Yaml(new Constructor(buildfarmConfigs.getClass(), new LoaderOptions()));
+      buildfarmConfigs = yaml.load(Files.newInputStream(configLocation));
+      if (buildfarmConfigs == null) {
+        throw new RuntimeException("Could not load configs from path: " + configLocation);
+      }
+      log.info(buildfarmConfigs.toString());
+      return buildfarmConfigs;
+    }
+
     try (InputStream inputStream = Files.newInputStream(configLocation)) {
       constructor =
           new BuildfarmConfigsConstructor(

--- a/src/test/java/build/buildfarm/common/config/BuildfarmConfigsTest.java
+++ b/src/test/java/build/buildfarm/common/config/BuildfarmConfigsTest.java
@@ -1,0 +1,77 @@
+package build.buildfarm.common.config;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class BuildfarmConfigsTest {
+  private Path tempDir;
+
+  @Before
+  public void setUp() throws IOException {
+    tempDir = Files.createTempDirectory("buildfarm-test");
+    BuildfarmConfigs configs = BuildfarmConfigs.getInstance();
+    configs.setServer(new Server());
+    configs.setBackplane(new Backplane());
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    Files.walk(tempDir)
+        .sorted((a, b) -> -a.compareTo(b))
+        .forEach(
+            path -> {
+              try {
+                Files.delete(path);
+              } catch (IOException e) {
+              }
+            });
+  }
+
+  @Test
+  public void loadConfigs_withRelativePathNoParent_shouldNotThrowNPE() throws IOException {
+    Path configFile = tempDir.resolve("server.yaml");
+    String yamlContent = "server:\n  port: 8980\n";
+    Files.write(configFile, yamlContent.getBytes());
+
+    BuildfarmConfigs configs = BuildfarmConfigs.loadConfigs(configFile);
+    assertNotNull(configs);
+  }
+
+  @Test
+  public void loadConfigs_withNonExistentFile_shouldThrowException() {
+    Path nonExistentFile = tempDir.resolve("nonexistent.yaml");
+    assertThrows(NoSuchFileException.class, () -> BuildfarmConfigs.loadConfigs(nonExistentFile));
+  }
+
+  @Test
+  public void loadConfigs_withInvalidYaml_shouldThrowException() throws IOException {
+    Path configFile = tempDir.resolve("invalid.yaml");
+    String invalidYaml = "invalid: yaml: content";
+    Files.write(configFile, invalidYaml.getBytes());
+
+    assertThrows(RuntimeException.class, () -> BuildfarmConfigs.loadConfigs(configFile));
+  }
+
+  @Test
+  public void loadConfigs_withValidYaml_shouldLoadSuccessfully() throws IOException {
+    Path configFile = tempDir.resolve("valid.yaml");
+    String validYaml = "server:\n  port: 8980\nbackplane:\n  redisUri: redis://localhost:6379";
+    Files.write(configFile, validYaml.getBytes());
+
+    BuildfarmConfigs configs = BuildfarmConfigs.loadConfigs(configFile);
+    assertNotNull(configs);
+    assertNotNull(configs.getServer());
+    assertNotNull(configs.getBackplane());
+  }
+}


### PR DESCRIPTION
Currently, running:
```
bazel run //src/main/java/build/buildfarm/server -- server.yaml
```
will fail with the NPE:
```
Exception in thread "main" java.lang.NullPointerException: Cannot invoke "java.nio.file.Path.toString()" because the return value of "java.nio.file.Path.getParent()" is null
	at build.buildfarm.common.config.BuildfarmConfigs.loadConfigs(BuildfarmConfigs.java:94)
	at build.buildfarm.common.config.BuildfarmConfigs.loadServerConfigs(BuildfarmConfigs.java:112)
	at build.buildfarm.server.BuildFarmServer.main(BuildFarmServer.java:267)
```
This was introduced in PR [#2219](https://github.com/buildfarm/buildfarm/pull/2219) which added support for the `!include` tag in YAML config files.

The issue occurs because:
1. The new `!include` feature requires resolving relative paths from the config file's parent directory
2. When running from the current directory with a relative path like `server.yaml`, the parent directory is null
3. The code was not handling this case, causing an NPE when calling toString() on the null parent
