### PR TITLE
chore: amend Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,6 +37,11 @@
       "enabled": false
     },
     {
+      "description": "disable helm-values",
+      "matchManagers": ["helm-values"],
+      "enabled": false
+    },
+    {
       "description": "Maven dependencies need to be pinned by 'REPIN=1 bazelisk run @maven//:pin && git add maven_install.json && git commit' to pass CI, then they can be auto-merged after approval",
       "matchManagers": ["bazel-module"],
       "matchDatasources": ["maven"],
@@ -66,7 +71,9 @@
       "matchPackageNames": [
         "com.google.errorprone:*",
         "net.jcip:jcip-annotations",
-        "org.checkerframework:checker-qual"
+        "org.checkerframework:checker-qual",
+        "org.jetbrains:annotations",
+        "org.jspecify:jspecify"
       ]
     },
     {


### PR DESCRIPTION
- add "org.jetbrains:annotations" and "org.jspecify:jspecify" to the annotations group (jspecify is a transitive dependency at the moment)
- ignore helm-values as we don't pin the buildfarm tag in the helm chart : it should make https://github.com/buildfarm/buildfarm/pull/2168 auto-close