### PR TITLE
feat(tools): Worker Profile Proxy

### DIFF
--- a/src/main/java/build/buildfarm/backplane/Backplane.java
+++ b/src/main/java/build/buildfarm/backplane/Backplane.java
@@ -122,6 +122,9 @@ public interface Backplane {
   /** Returns a set of the names of all active storage workers. */
   Set<String> getStorageWorkers() throws IOException;
 
+  /** Returns a set of the names of all active execute workers. */
+  Set<String> getExecuteWorkers() throws IOException;
+
   // TODO this is just a namespace, but kind of jank for just digest function as a string...
   /**
    * The AC stores full ActionResult objects in a hash map where the key is the digest of the action

--- a/src/main/java/build/buildfarm/common/config/Worker.java
+++ b/src/main/java/build/buildfarm/common/config/Worker.java
@@ -75,6 +75,11 @@ public class Worker {
     return executionPolicies;
   }
 
+  /**
+   * The type of worker
+   *
+   * @return A bitmask of {@class build.buildfarm.v1test.WorkerType} enum
+   */
   public int getWorkerType() {
     int workerType = 0;
     if (getCapabilities().isCas()) {

--- a/src/main/java/build/buildfarm/instance/Instance.java
+++ b/src/main/java/build/buildfarm/instance/Instance.java
@@ -159,7 +159,7 @@ public interface Instance {
 
   ServerCapabilities getCapabilities();
 
-  WorkerProfileMessage getWorkerProfile();
+  WorkerProfileMessage getWorkerProfile(String workerName);
 
   WorkerListMessage getWorkerList();
 

--- a/src/main/java/build/buildfarm/instance/server/NodeInstance.java
+++ b/src/main/java/build/buildfarm/instance/server/NodeInstance.java
@@ -1769,7 +1769,7 @@ public abstract class NodeInstance extends InstanceBase {
   }
 
   @Override
-  public WorkerProfileMessage getWorkerProfile() {
+  public WorkerProfileMessage getWorkerProfile(String workerName) {
     throw new UnsupportedOperationException(
         "NodeInstance doesn't support getWorkerProfile() method.");
   }

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -789,7 +789,8 @@ public class RedisShardBackplane implements Backplane {
     return client.call(jedis -> createCasWorkerMap(jedis).insertTime(blobDigest));
   }
 
-  private synchronized Set<String> getExecuteWorkers() throws IOException {
+  @Override
+  public synchronized Set<String> getExecuteWorkers() throws IOException {
     try {
       return recentExecuteWorkers.get();
     } catch (RuntimeException e) {

--- a/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
@@ -102,6 +102,8 @@ import build.buildfarm.v1test.QueueStatus;
 import build.buildfarm.v1test.QueuedOperation;
 import build.buildfarm.v1test.QueuedOperationMetadata;
 import build.buildfarm.v1test.Tree;
+import build.buildfarm.v1test.WorkerListMessage;
+import build.buildfarm.v1test.WorkerProfileMessage;
 import com.github.benmanes.caffeine.cache.AsyncCache;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -3280,5 +3282,23 @@ public class ServerInstance extends NodeInstance {
       throws IOException {
     // TODO maybe track per server instance as well
     backplane.incrementRequestCounters(actionId, toolInvocationId, actionMnemonic, targetId);
+  }
+
+  @Override
+  public WorkerListMessage getWorkerList() {
+    try {
+      Set allWorkers = backplane.getStorageWorkers();
+      // TODO add exec workers too.
+      WorkerListMessage.Builder b = WorkerListMessage.newBuilder();
+      b.addAllWorkers(allWorkers);
+      return b.build();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public WorkerProfileMessage getWorkerProfile(String workerName) {
+    return workerStub(workerName).getWorkerProfile(workerName);
   }
 }

--- a/src/main/java/build/buildfarm/instance/stub/StubInstance.java
+++ b/src/main/java/build/buildfarm/instance/stub/StubInstance.java
@@ -938,9 +938,9 @@ public class StubInstance extends InstanceBase {
   }
 
   @Override
-  public WorkerProfileMessage getWorkerProfile() {
+  public WorkerProfileMessage getWorkerProfile(String workerName) {
     return deadlined(workerProfileBlockingStub)
-        .getWorkerProfile(WorkerProfileRequest.newBuilder().build());
+        .getWorkerProfile(WorkerProfileRequest.newBuilder().setWorker(workerName).build());
   }
 
   @Override

--- a/src/main/java/build/buildfarm/server/BuildFarmServer.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmServer.java
@@ -37,6 +37,7 @@ import build.buildfarm.server.services.FetchService;
 import build.buildfarm.server.services.OperationQueueService;
 import build.buildfarm.server.services.OperationsService;
 import build.buildfarm.server.services.PublishBuildEventService;
+import build.buildfarm.server.services.WorkerProfileProxyService;
 import io.grpc.ServerBuilder;
 import io.grpc.ServerInterceptor;
 import io.grpc.health.v1.HealthCheckResponse.ServingStatus;
@@ -160,6 +161,7 @@ public class BuildFarmServer extends LoggingMain {
         .addService(new OperationsService(instance))
         .addService(new FetchService(instance))
         .addService(ProtoReflectionService.newInstance())
+        .addService(new WorkerProfileProxyService(instance))
         .addService(new PublishBuildEventService())
         .intercept(TransmitStatusRuntimeExceptionInterceptor.instance())
         .intercept(headersInterceptor);

--- a/src/main/java/build/buildfarm/server/services/BUILD
+++ b/src/main/java/build/buildfarm/server/services/BUILD
@@ -6,6 +6,7 @@ java_library(
     plugins = ["//src/main/java/build/buildfarm/common:lombok"],
     visibility = ["//visibility:public"],
     deps = [
+        "//src/main/java/build/buildfarm/backplane",
         "//src/main/java/build/buildfarm/common",
         "//src/main/java/build/buildfarm/common/config",
         "//src/main/java/build/buildfarm/common/grpc",

--- a/src/main/java/build/buildfarm/server/services/WorkerProfileProxyService.java
+++ b/src/main/java/build/buildfarm/server/services/WorkerProfileProxyService.java
@@ -1,0 +1,36 @@
+package build.buildfarm.server.services;
+
+import build.buildfarm.instance.Instance;
+import build.buildfarm.v1test.WorkerListMessage;
+import build.buildfarm.v1test.WorkerListRequest;
+import build.buildfarm.v1test.WorkerProfileGrpc;
+import build.buildfarm.v1test.WorkerProfileMessage;
+import build.buildfarm.v1test.WorkerProfileRequest;
+import io.grpc.stub.StreamObserver;
+
+/** an implementation of WorkerProfileService that delegates to one of the Workers. */
+public class WorkerProfileProxyService extends WorkerProfileGrpc.WorkerProfileImplBase {
+  //    private final Backplane backplane = null;
+  private final Instance instance;
+
+  public WorkerProfileProxyService(Instance instance) {
+    this.instance = instance;
+  }
+
+  @Override
+  public void getWorkerProfile(
+      WorkerProfileRequest request, StreamObserver<WorkerProfileMessage> responseObserver) {
+    // get usage of CASFileCache
+
+    responseObserver.onNext(instance.getWorkerProfile(request.getWorker()));
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void getWorkerList(
+      WorkerListRequest request, StreamObserver<WorkerListMessage> responseObserver) {
+    WorkerListMessage m = instance.getWorkerList();
+    responseObserver.onNext(m);
+    responseObserver.onCompleted();
+  }
+}

--- a/src/main/java/build/buildfarm/tools/Cat.java
+++ b/src/main/java/build/buildfarm/tools/Cat.java
@@ -77,6 +77,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -684,8 +685,8 @@ class Cat {
     System.out.println(DigestUtil.toString(digest.get()));
   }
 
-  private static void getWorkerProfile(Instance instance) {
-    WorkerProfileMessage response = instance.getWorkerProfile();
+  private static void getWorkerProfile(Instance instance, String workerName) {
+    WorkerProfileMessage response = instance.getWorkerProfile(workerName);
     System.out.println("\nWorkerProfile:");
     String strIntFormat = "%-50s : %d";
     long entryCount = response.getCasEntryCount();
@@ -863,7 +864,9 @@ class Cat {
 
     @Override
     public void run(Instance instance, Iterable<String> args) {
-      getWorkerProfile(instance);
+      Iterator<String> argsIterator = args.iterator();
+      String workerName = argsIterator.hasNext() ? argsIterator.next() : null;
+      getWorkerProfile(instance, workerName);
     }
   }
 

--- a/src/main/java/build/buildfarm/tools/WorkerProfile.java
+++ b/src/main/java/build/buildfarm/tools/WorkerProfile.java
@@ -16,50 +16,23 @@ package build.buildfarm.tools;
 
 import static build.buildfarm.common.grpc.Channels.createChannel;
 
-import build.buildfarm.common.config.BuildfarmConfigs;
-import build.buildfarm.common.config.ShardWorkerOptions;
-import build.buildfarm.common.redis.RedisClient;
 import build.buildfarm.instance.Instance;
-import build.buildfarm.instance.shard.JedisClusterFactory;
 import build.buildfarm.instance.stub.StubInstance;
 import build.buildfarm.v1test.OperationTimesBetweenStages;
-import build.buildfarm.v1test.ShardWorker;
 import build.buildfarm.v1test.StageInformation;
 import build.buildfarm.v1test.WorkerProfileMessage;
-import com.google.common.collect.Sets;
-import com.google.devtools.common.options.OptionsParser;
-import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.util.Durations;
-import com.google.protobuf.util.JsonFormat;
 import io.grpc.StatusRuntimeException;
 import java.io.IOException;
-import java.nio.file.Path;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import javax.naming.ConfigurationException;
-import redis.clients.jedis.UnifiedJedis;
 
 class WorkerProfile {
-  private static BuildfarmConfigs configs = BuildfarmConfigs.getInstance();
-
-  /**
-   * Transform worker string from "ip-10-135-31-210.ec2:8981" to "10.135.31.210".
-   *
-   * @param worker
-   * @return
-   */
-  @SuppressWarnings("JavaDoc")
-  private static String workerStringTransformation(String worker) {
-    return worker.split("\\.")[0].substring("ip-".length()).replaceAll("-", ".")
-        + ':'
-        + worker.split(":")[1];
-  }
 
   private static void analyzeMessage(String worker, WorkerProfileMessage response) {
-    System.out.println("\nWorkerProfile:");
-    System.out.println(worker);
+    System.out.println("\nWorkerProfile: " + worker);
     String strIntFormat = "%-50s : %d";
     long entryCount = response.getCasEntryCount();
     long unreferencedEntryCount = response.getCasUnreferencedEntryCount();
@@ -95,86 +68,41 @@ class WorkerProfile {
   }
 
   @SuppressWarnings("ConstantConditions")
-  private static Set<String> getWorkers(String[] args) throws ConfigurationException, IOException {
-    OptionsParser parser = OptionsParser.newOptionsParser(ShardWorkerOptions.class);
-    parser.parseAndExitUponError(args);
-    List<String> residue = parser.getResidue();
-    if (residue.isEmpty()) {
-      throw new IllegalArgumentException("Missing Config_PATH");
-    }
-    try {
-      configs.loadConfigs(Path.of(residue.get(3)));
-    } catch (IOException e) {
-      System.out.println("Could not parse yml configuration file." + e);
-    }
-    RedisClient client = new RedisClient(JedisClusterFactory.create("worker-profile").get());
-    return client.call(jedis -> fetchWorkers(jedis, System.currentTimeMillis()));
-  }
-
-  private static Set<String> fetchWorkers(UnifiedJedis jedis, long now) {
-    Set<String> workers = Sets.newConcurrentHashSet();
-    for (Map.Entry<String, String> entry :
-        jedis.hgetAll(configs.getBackplane().getWorkersHashName() + "_storage").entrySet()) {
-      String json = entry.getValue();
-      try {
-        if (json != null) {
-          ShardWorker.Builder builder = ShardWorker.newBuilder();
-          JsonFormat.parser().merge(json, builder);
-          ShardWorker worker = builder.build();
-          if (worker.getExpireAt() > now) {
-            workers.add(worker.getEndpoint());
-          }
-        }
-      } catch (InvalidProtocolBufferException e) {
-        e.printStackTrace();
-      }
-    }
-    return workers;
+  private static Set<String> getWorkers(Instance instance)
+      throws ConfigurationException, IOException {
+    ImmutableSet.Builder<String> builder = ImmutableSet.builder();
+    builder.addAll(instance.getWorkerList().getWorkersList());
+    return builder.build();
   }
 
   @SuppressWarnings("BusyWait")
   private static void workerProfile(String[] args) throws IOException {
     Set<String> workers = null;
     WorkerProfileMessage currentWorkerMessage;
-    HashMap<String, Instance> workersToChannels = new HashMap<>();
-    String type = args[1];
+    String serverUri = args[0];
+    String instanceName = args[1];
+
+    Instance serverInstance =
+        new StubInstance(
+            instanceName, "bf-workerprofile", createChannel(serverUri), Durations.fromMinutes(1));
 
     //noinspection InfiniteLoopStatement
     while (true) {
       // update worker list
       if (workers == null) {
         try {
-          workers = getWorkers(args);
+          workers = getWorkers(serverInstance);
         } catch (ConfigurationException e) {
           e.printStackTrace();
         }
       }
       if (workers == null || workers.isEmpty()) {
-        System.out.println(
-            "cannot find any workers, check the redis url and make sure there are workers in the"
-                + " cluster");
+        System.out.println("cannot find any workers");
       } else {
-        // remove the unregistered workers
-        for (String existingWorker : workersToChannels.keySet()) {
-          if (!workers.contains(existingWorker)) {
-            workersToChannels.remove(existingWorker);
-          }
-        }
-
         // add new registered workers and profile
         for (String worker : workers) {
-          if (!workersToChannels.containsKey(worker)) {
-            workersToChannels.put(
-                worker,
-                new StubInstance(
-                    type,
-                    "bf-workerprofile",
-                    createChannel(workerStringTransformation(worker)),
-                    Durations.fromMinutes(1)));
-          }
           try {
-            currentWorkerMessage = workersToChannels.get(worker).getWorkerProfile();
-            System.out.println(worker);
+            currentWorkerMessage = serverInstance.getWorkerProfile(worker);
             analyzeMessage(worker, currentWorkerMessage);
           } catch (StatusRuntimeException e) {
             e.printStackTrace();
@@ -193,8 +121,9 @@ class WorkerProfile {
     }
   }
 
-  // how to run the binary: bf-workerprofile WorkerProfile shard SHA256
-  // examples/config.yml
+  // how to run the binary:
+  // bazel run //src/main/java/build/buildfarm/tools:bf-workerprofile grpc://localhost:8980 shard
+  // SHA256
   public static void main(String[] args) throws Exception {
     workerProfile(args);
   }

--- a/src/main/java/build/buildfarm/tools/WorkerProfilePrinter.java
+++ b/src/main/java/build/buildfarm/tools/WorkerProfilePrinter.java
@@ -25,9 +25,9 @@ import com.google.protobuf.util.Durations;
 import java.util.List;
 
 class WorkerProfilePrinter {
-  public static void getWorkerProfile(Instance instance) {
-    WorkerProfileMessage response = instance.getWorkerProfile();
-    System.out.println("\nWorkerProfile:");
+  public static void getWorkerProfile(Instance instance, String workerName) {
+    WorkerProfileMessage response = instance.getWorkerProfile(workerName);
+    System.out.println("\nWorkerProfile: " + workerName);
     String strIntFormat = "%-50s : %d";
     long entryCount = response.getCasEntryCount();
     long unreferencedEntryCount = response.getCasUnreferencedEntryCount();

--- a/src/main/java/build/buildfarm/worker/shard/BUILD
+++ b/src/main/java/build/buildfarm/worker/shard/BUILD
@@ -39,6 +39,7 @@ java_library(
         "@maven//:io_grpc_grpc_stub",
         "@maven//:io_prometheus_simpleclient",
         "@maven//:javax_annotation_javax_annotation_api",
+        "@maven//:org_apache_commons_commons_lang3",
         "@maven//:org_projectlombok_lombok",
     ],
 )

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -273,8 +273,7 @@ public final class Worker extends LoggingMain {
               inputFetchStage,
               executeActionStage,
               reportResultStage,
-              completeStage,
-              backplane));
+              completeStage));
     }
     GrpcMetrics.handleGrpcMetricIntercepts(serverBuilder, configs.getWorker().getGrpcMetrics());
     serverBuilder.intercept(new ServerHeadersInterceptor(meta -> {}));

--- a/src/main/java/build/buildfarm/worker/shard/WorkerProfileService.java
+++ b/src/main/java/build/buildfarm/worker/shard/WorkerProfileService.java
@@ -28,8 +28,8 @@ import build.buildfarm.worker.PutOperationStage.OperationStageDurations;
 import build.buildfarm.worker.SuperscalarPipelineStage;
 import com.google.common.base.Strings;
 import io.grpc.stub.StreamObserver;
-import java.io.IOException;
 import javax.annotation.Nullable;
+import org.apache.commons.lang3.NotImplementedException;
 
 public class WorkerProfileService extends WorkerProfileGrpc.WorkerProfileImplBase {
   private final @Nullable CASFileCache storage;
@@ -126,17 +126,10 @@ public class WorkerProfileService extends WorkerProfileGrpc.WorkerProfileImplBas
     responseObserver.onNext(replyBuilder.build());
     responseObserver.onCompleted();
   }
-
   @Override
   public void getWorkerList(
-      WorkerListRequest request, StreamObserver<WorkerListMessage> responseObserver) {
-    WorkerListMessage.Builder replyBuilder = WorkerListMessage.newBuilder();
-    try {
-      replyBuilder.addAllWorkers(backplane.getStorageWorkers());
-    } catch (IOException e) {
-      responseObserver.onError(e);
-    }
-    responseObserver.onNext(replyBuilder.build());
-    responseObserver.onCompleted();
+          WorkerListRequest request, StreamObserver<WorkerListMessage> responseObserver) {
+    throw new NotImplementedException();
   }
+
 }

--- a/src/main/java/build/buildfarm/worker/shard/WorkerProfileService.java
+++ b/src/main/java/build/buildfarm/worker/shard/WorkerProfileService.java
@@ -33,20 +33,20 @@ import org.apache.commons.lang3.NotImplementedException;
 
 public class WorkerProfileService extends WorkerProfileGrpc.WorkerProfileImplBase {
   private final @Nullable CASFileCache storage;
-  private final PipelineStage matchStage;
-  private final SuperscalarPipelineStage inputFetchStage;
-  private final SuperscalarPipelineStage executeActionStage;
-  private final SuperscalarPipelineStage reportResultStage;
-  private final PutOperationStage completeStage;
+  private final @Nullable PipelineStage matchStage;
+  private final @Nullable SuperscalarPipelineStage inputFetchStage;
+  private final @Nullable SuperscalarPipelineStage executeActionStage;
+  private final @Nullable SuperscalarPipelineStage reportResultStage;
+  private final @Nullable PutOperationStage completeStage;
   private final Backplane backplane;
 
   public WorkerProfileService(
       @Nullable CASFileCache storage,
-      PipelineStage matchStage,
-      SuperscalarPipelineStage inputFetchStage,
-      SuperscalarPipelineStage executeActionStage,
-      SuperscalarPipelineStage reportResultStage,
-      PutOperationStage completeStage,
+      @Nullable PipelineStage matchStage,
+      @Nullable SuperscalarPipelineStage inputFetchStage,
+      @Nullable SuperscalarPipelineStage executeActionStage,
+      @Nullable SuperscalarPipelineStage reportResultStage,
+      @Nullable PutOperationStage completeStage,
       Backplane backplane) {
     super();
     this.storage = storage;
@@ -101,35 +101,43 @@ public class WorkerProfileService extends WorkerProfileGrpc.WorkerProfileImplBas
     // produce: slots that are not consistent with operations, operations
     // in multiple stages even in reverse due to claim progress
     // in short: this is for monitoring, not for guaranteed consistency checks
-    String matchOperation = matchStage.getOperationName();
-    replyBuilder
-        .addStages(superscalarStageInformation(reportResultStage))
-        .addStages(superscalarStageInformation(executeActionStage))
-        .addStages(superscalarStageInformation(inputFetchStage))
-        .addStages(unaryStageInformation(matchStage.getName(), matchOperation));
-
+    if (reportResultStage != null) {
+      replyBuilder.addStages(superscalarStageInformation(reportResultStage));
+    }
+    if (executeActionStage != null) {
+      replyBuilder.addStages(superscalarStageInformation(executeActionStage));
+    }
+    if (inputFetchStage != null) {
+      replyBuilder.addStages(superscalarStageInformation(inputFetchStage));
+    }
+    if (matchStage != null) {
+      String matchOperation = matchStage.getOperationName();
+      replyBuilder.addStages(unaryStageInformation(matchStage.getName(), matchOperation));
+    }
     // get average time costs on each stage
-    OperationStageDurations[] durations = completeStage.getAverageTimeCostPerStage();
-    for (OperationStageDurations duration : durations) {
-      replyBuilder
-          .addTimesBuilder()
-          .setQueuedToMatch(duration.queuedToMatch)
-          .setMatchToInputFetchStart(duration.matchToInputFetchStart)
-          .setInputFetchStartToComplete(duration.inputFetchStartToComplete)
-          .setInputFetchCompleteToExecutionStart(duration.inputFetchCompleteToExecutionStart)
-          .setExecutionStartToComplete(duration.executionStartToComplete)
-          .setExecutionCompleteToOutputUploadStart(duration.executionCompleteToOutputUploadStart)
-          .setOutputUploadStartToComplete(duration.outputUploadStartToComplete)
-          .setOperationCount(duration.operationCount)
-          .setPeriod(duration.period);
+    if (completeStage != null) {
+      OperationStageDurations[] durations = completeStage.getAverageTimeCostPerStage();
+      for (OperationStageDurations duration : durations) {
+        replyBuilder
+            .addTimesBuilder()
+            .setQueuedToMatch(duration.queuedToMatch)
+            .setMatchToInputFetchStart(duration.matchToInputFetchStart)
+            .setInputFetchStartToComplete(duration.inputFetchStartToComplete)
+            .setInputFetchCompleteToExecutionStart(duration.inputFetchCompleteToExecutionStart)
+            .setExecutionStartToComplete(duration.executionStartToComplete)
+            .setExecutionCompleteToOutputUploadStart(duration.executionCompleteToOutputUploadStart)
+            .setOutputUploadStartToComplete(duration.outputUploadStartToComplete)
+            .setOperationCount(duration.operationCount)
+            .setPeriod(duration.period);
+      }
     }
     responseObserver.onNext(replyBuilder.build());
     responseObserver.onCompleted();
   }
+
   @Override
   public void getWorkerList(
-          WorkerListRequest request, StreamObserver<WorkerListMessage> responseObserver) {
+      WorkerListRequest request, StreamObserver<WorkerListMessage> responseObserver) {
     throw new NotImplementedException();
   }
-
 }

--- a/src/main/java/build/buildfarm/worker/shard/WorkerProfileService.java
+++ b/src/main/java/build/buildfarm/worker/shard/WorkerProfileService.java
@@ -14,7 +14,6 @@
 
 package build.buildfarm.worker.shard;
 
-import build.buildfarm.backplane.Backplane;
 import build.buildfarm.cas.cfc.CASFileCache;
 import build.buildfarm.v1test.StageInformation;
 import build.buildfarm.v1test.WorkerListMessage;
@@ -38,7 +37,6 @@ public class WorkerProfileService extends WorkerProfileGrpc.WorkerProfileImplBas
   private final @Nullable SuperscalarPipelineStage executeActionStage;
   private final @Nullable SuperscalarPipelineStage reportResultStage;
   private final @Nullable PutOperationStage completeStage;
-  private final Backplane backplane;
 
   public WorkerProfileService(
       @Nullable CASFileCache storage,
@@ -46,8 +44,7 @@ public class WorkerProfileService extends WorkerProfileGrpc.WorkerProfileImplBas
       @Nullable SuperscalarPipelineStage inputFetchStage,
       @Nullable SuperscalarPipelineStage executeActionStage,
       @Nullable SuperscalarPipelineStage reportResultStage,
-      @Nullable PutOperationStage completeStage,
-      Backplane backplane) {
+      @Nullable PutOperationStage completeStage) {
     super();
     this.storage = storage;
     this.matchStage = matchStage;
@@ -55,7 +52,6 @@ public class WorkerProfileService extends WorkerProfileGrpc.WorkerProfileImplBas
     this.executeActionStage = executeActionStage;
     this.reportResultStage = reportResultStage;
     this.completeStage = (PutOperationStage) completeStage;
-    this.backplane = backplane;
   }
 
   private StageInformation unaryStageInformation(String name, @Nullable String operationName) {

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -626,7 +626,9 @@ message WorkerProfileMessage {
   repeated OperationTimesBetweenStages times = 10;
 }
 
-message WorkerProfileRequest {}
+message WorkerProfileRequest {
+  string worker = 1; // The worker identifier from GetWorkerList()
+}
 
 message WorkerListRequest {}
 

--- a/src/test/java/build/buildfarm/instance/DummyInstanceBase.java
+++ b/src/test/java/build/buildfarm/instance/DummyInstanceBase.java
@@ -209,7 +209,7 @@ class DummyInstanceBase extends InstanceBase {
   }
 
   @Override
-  public WorkerProfileMessage getWorkerProfile() {
+  public WorkerProfileMessage getWorkerProfile(String workerName) {
     throw new UnsupportedOperationException();
   }
 

--- a/src/test/java/build/buildfarm/instance/server/NodeInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/server/NodeInstanceTest.java
@@ -205,7 +205,7 @@ public class NodeInstanceTest {
     }
 
     @Override
-    public WorkerProfileMessage getWorkerProfile() {
+    public WorkerProfileMessage getWorkerProfile(String workerName) {
       throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
Proxy the `WorkerProfile` gRPC service from server->worker.

There's a new field in the gRPC service for the `workerName`. The worker does not validate it (for backwards compatibility with existing tools).

I'll open a PR against https://github.com/werkt/bf-client to utilize this as well.