### PR TITLE
fix(worker): prevent leaks in ZSTD during decompression

### DIFF
--- a/src/main/java/build/buildfarm/common/ZstdDecompressingOutputStream.java
+++ b/src/main/java/build/buildfarm/common/ZstdDecompressingOutputStream.java
@@ -129,15 +129,27 @@ public final class ZstdDecompressingOutputStream extends FeedbackOutputStream {
 
   @Override
   public void write(byte[] b, int off, int len) throws IOException {
-    inner = new ByteArrayInputStream(b, off, len);
-    byte[] data = ByteString.readFrom(zis).toByteArray();
-    out.write(data, 0, data.length);
+    try {
+      inner = new ByteArrayInputStream(b, off, len);
+      byte[] data = ByteString.readFrom(zis).toByteArray();
+      out.write(data, 0, data.length);
+    } catch (Exception e) {
+      try {
+        zis.close();
+      } catch (IOException ignored) {
+        // Ignore close errors during cleanup
+      }
+      throw e;
+    }
   }
 
   @Override
   public void close() throws IOException {
-    zis.close();
-    out.close();
+    try {
+      zis.close();
+    } finally {
+      out.close();
+    }
   }
 
   @Override


### PR DESCRIPTION
After upgrading from 2.10.2, we're seeing file descriptor leaks on workers when using cache compression. The issue manifests as:
- Growing number of open FDs
- Write errors (75% unknown, 25% deadline exceeded)
- ZstdIOException: Data corruption detected errors
- Only occurs with compression enabled

The root cause is that when ZSTD operations fail (due to corruption or timeouts), the ZSTD streams and their associated resources aren't properly closed. This leads to file descriptor leaks and can cause cascading failures.

This PR makes an attempt to cleanup of ZSTD resources in both success and error cases:

This ensures that even when ZSTD operations fail due to corruption or timeouts, all resources are properly cleaned up, preventing FD leaks and allowing the system to recover gracefully.