### PR TITLE
Only pause poller reliably when stage has not released control

### DIFF
--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -84,6 +84,7 @@ class Executor {
   private final java.util.concurrent.Executor pollerExecutor;
   private int exitCode = INCOMPLETE_EXIT_CODE;
   private boolean wasErrored = false;
+  private boolean polling = false;
 
   Executor(
       WorkerContext workerContext,
@@ -175,10 +176,13 @@ class Executor {
       policies = Iterables.concat(policies, workerContext.getExecutionPolicies("pool-" + pool));
     }
 
+    polling = true;
     try {
       return executePolled(limits, policies, timeout, stopwatch);
     } finally {
-      executionContext.poller.pause();
+      if (polling) {
+        executionContext.poller.pause();
+      }
     }
   }
 
@@ -410,6 +414,7 @@ class Executor {
         }
       }
     }
+    polling = false;
     return stopwatch.elapsed(MICROSECONDS) - executeUSecs;
   }
 

--- a/src/main/java/build/buildfarm/worker/InputFetcher.java
+++ b/src/main/java/build/buildfarm/worker/InputFetcher.java
@@ -62,6 +62,7 @@ public class InputFetcher implements Runnable {
   private final InputFetchStage owner;
   private final Executor pollerExecutor;
   private boolean success = false;
+  private boolean polling = false;
 
   InputFetcher(
       WorkerContext workerContext,
@@ -112,10 +113,13 @@ public class InputFetcher implements Runnable {
         Thread.currentThread()::interrupt,
         Deadline.after(workerContext.getInputFetchDeadline(), SECONDS),
         pollerExecutor);
+    polling = true;
     try {
       return fetchPolled(stopwatch);
     } finally {
-      executionContext.poller.pause();
+      if (polling) {
+        executionContext.poller.pause();
+      }
     }
   }
 
@@ -319,6 +323,7 @@ public class InputFetcher implements Runnable {
 
       owner.error().put(fetchedExecutionContext);
     }
+    polling = false;
   }
 
   @Override


### PR DESCRIPTION
The finally poller pause could race with resumption by subsequent stages. This should only be done in the event of a failure, and if responsibility is released, it must not interact with it.

ReportResultStage is the anomaly here, where it does not require conditional pause of the poller.