### PR TITLE
fix: Hist tool incorrect list name

### DIFF
--- a/src/main/java/build/buildfarm/tools/Hist.java
+++ b/src/main/java/build/buildfarm/tools/Hist.java
@@ -51,7 +51,7 @@ class Hist {
     do {
       pageToken =
           instance.listOperations(
-              instance.getName() + "/executions",
+              "executions",
               LIST_OPERATIONS_MAXIMUM_PAGE_SIZE,
               pageToken,
               "status=dispatched",


### PR DESCRIPTION
Fixing the name from `bf-cat`