### PR TITLE
fix:(groups): exec width vs processors

### DIFF
--- a/src/main/java/build/buildfarm/common/SystemProcessors.java
+++ b/src/main/java/build/buildfarm/common/SystemProcessors.java
@@ -43,13 +43,24 @@ public class SystemProcessors {
   }
 
   /**
+   * @field cachedProcessorCount
+   * @brief Cached processor count.
+   * @details We cache the processor count since it won't change during runtime.
+   */
+  private static Integer cachedProcessorCount = null;
+
+  /**
    * @brief Get the number of logical processors on the system.
    * @details Buildfarm will choose the best implementation.
    * @return Number of logical processors on the system.
    */
   public static int get() {
-    // Have buildfarm choose the best value.
-    return Math.max(get(PROCESSOR_DERIVE.JAVA_RUNTIME), get(PROCESSOR_DERIVE.OSHI));
+    // Cache the processor count since it won't change during runtime
+    if (cachedProcessorCount == null) {
+      cachedProcessorCount =
+          Math.max(get(PROCESSOR_DERIVE.JAVA_RUNTIME), get(PROCESSOR_DERIVE.OSHI));
+    }
+    return cachedProcessorCount;
   }
 
   /**

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -828,10 +828,7 @@ class ShardWorkerContext implements WorkerContext {
 
   void createOperationExecutionLimits() {
     try {
-      int availableProcessors = SystemProcessors.get();
-      Preconditions.checkState(availableProcessors >= executeStageWidth);
-      executionsGroup.getCpu().setMaxCpu(executeStageWidth);
-      if (executeStageWidth < availableProcessors) {
+      if (executeStageWidth < SystemProcessors.get()) {
         /* only divide up our cfs quota if we need to limit below the available processors for executions */
         executionsGroup.getCpu().setMaxCpu(executeStageWidth);
       }


### PR DESCRIPTION
- We were unconditionally setting `executionsGroup.getCpu().setMaxCpu()`, and then conditionally setting it inside an `if`.
- Remove a `Precondition` check.

Also, for performance, no need to check system processor count over and over. Memoize it.
