### PR TITLE
Made execOwner and execOwners work with persistent workers

### DIFF
--- a/persistentworkers/src/main/java/persistent/bazel/BUILD
+++ b/persistentworkers/src/main/java/persistent/bazel/BUILD
@@ -8,7 +8,9 @@ java_library(
     deps = [
         "//persistentworkers/src/main/java/persistent/common:persistent-common",
         "//persistentworkers/src/main/protobuf:worker_protocol_java_proto",
+        "//src/main/java/build/buildfarm/common",
         "@maven//:com_github_pcj_google_options",
+        "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:com_google_protobuf_protobuf_java_util",

--- a/persistentworkers/src/main/java/persistent/bazel/client/WorkerSupervisor.java
+++ b/persistentworkers/src/main/java/persistent/bazel/client/WorkerSupervisor.java
@@ -11,15 +11,6 @@ import org.apache.commons.pool2.impl.DefaultPooledObject;
 import persistent.common.CommonsSupervisor;
 
 public abstract class WorkerSupervisor extends CommonsSupervisor<WorkerKey, PersistentWorker> {
-  public static WorkerSupervisor simple() {
-    return new WorkerSupervisor() {
-      @Override
-      public PersistentWorker create(WorkerKey workerKey) throws Exception {
-        return new PersistentWorker(workerKey, "");
-      }
-    };
-  }
-
   private final Logger logger = Logger.getLogger(this.getClass().getName());
 
   public abstract PersistentWorker create(WorkerKey workerKey) throws Exception;

--- a/persistentworkers/src/test/java/persistent/bazel/BUILD
+++ b/persistentworkers/src/test/java/persistent/bazel/BUILD
@@ -39,5 +39,5 @@ java_test(
     resources = [
         "//persistentworkers/examples/src/main/java:adder-bin_deploy.jar",
     ],
-    deps = COMMON_DEPS,
+    deps = COMMON_DEPS + ["//src/main/java/build/buildfarm/common"],
 )

--- a/persistentworkers/src/test/java/persistent/bazel/processes/PersistentWorkerTest.java
+++ b/persistentworkers/src/test/java/persistent/bazel/processes/PersistentWorkerTest.java
@@ -1,11 +1,19 @@
 package persistent.bazel.processes;
 
+import build.buildfarm.common.Claim;
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.worker.WorkerProtocol.WorkRequest;
 import com.google.devtools.build.lib.worker.WorkerProtocol.WorkResponse;
 import java.io.IOException;
+import java.nio.file.FileSystemException;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.UserPrincipal;
+import java.nio.file.attribute.UserPrincipalLookupService;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map.Entry;
 import java.util.Optional;
 import org.junit.Assert;
 import org.junit.Test;
@@ -19,6 +27,39 @@ import persistent.testutil.WorkerUtils;
 
 @RunWith(JUnit4.class)
 public class PersistentWorkerTest {
+  static class StubClaim implements Claim {
+    private final UserPrincipal owner;
+    private boolean released = false;
+
+    public StubClaim(UserPrincipal owner) {
+      this.owner = owner;
+    }
+
+    @Override
+    public Iterable<Entry<String, List<Object>>> getPools() {
+      return Collections.emptyList();
+    }
+
+    public boolean isReleased() {
+      return released;
+    }
+
+    @Override
+    public UserPrincipal owner() {
+      return owner;
+    }
+
+    @Override
+    public void release(Stage stage) {
+      released = true;
+    }
+
+    @Override
+    public void release() {
+      released = true;
+    }
+  }
+
   static WorkResponse sendAddRequest(PersistentWorker worker, Path stdErrLog, int x, int y)
       throws IOException {
     ImmutableList<String> arguments = ImmutableList.of(String.valueOf(x), String.valueOf(y));
@@ -59,7 +100,7 @@ public class PersistentWorkerTest {
     WorkerKey key = WorkerUtils.emptyWorkerKey(workDir, initCmd);
 
     Path stdErrLog = workDir.resolve("test-err.log");
-    PersistentWorker worker = new PersistentWorker(key, "worker-dir");
+    PersistentWorker worker = new PersistentWorker(key, "worker-dir", null);
 
     WorkResponse response = sendAddRequest(worker, stdErrLog, 2, 4);
 
@@ -72,5 +113,60 @@ public class PersistentWorkerTest {
     Assert.assertEquals(response2.getOutput(), "50");
     Assert.assertEquals(response2.getExitCode(), 0);
     Assert.assertEquals(worker.getExitValue(), Optional.empty()); // Not yet exited
+  }
+
+  @Test
+  public void execOwnerSet() throws Exception {
+    Path workDir = Files.createTempDirectory("test-workdir-");
+
+    String filename = "adder-bin_deploy.jar";
+
+    Path jarPath =
+        ProcessUtils.retrieveFileResource(
+            getClass().getClassLoader(), filename, workDir.resolve(filename));
+
+    ImmutableList<String> initCmd =
+        ImmutableList.of(
+            JavaProcessWrapper.CURRENT_JVM_COMMAND,
+            "-cp",
+            jarPath.toString(),
+            "adder.Adder",
+            "--persistent_worker");
+
+    WorkerKey key = WorkerUtils.emptyWorkerKey(workDir, initCmd);
+
+    UserPrincipalLookupService lookupService =
+        FileSystems.getDefault().getUserPrincipalLookupService();
+
+    UserPrincipal nobody = lookupService.lookupPrincipalByName("nobody");
+
+    StubClaim nobodyClaim = new StubClaim(nobody);
+
+    Path execRoot = workDir.resolve("worker-dir");
+
+    try {
+      PersistentWorker worker = new PersistentWorker(key, "worker-dir", nobodyClaim);
+
+      Assert.assertEquals(Files.getOwner(execRoot), nobody);
+
+      worker.destroy();
+
+      Assert.assertTrue(nobodyClaim.isReleased());
+    } catch (FileSystemException exception) {
+      /*
+       * It's likely that the current user doesn't have permission to change the owner of `execRoot`, in which case we
+       * should ignore the exception and assume `PersistentWorker` attempted to change the owner of the correct directory.
+       */
+    }
+
+    // Test that the claim is released when the worker is destroyed
+    StubClaim meClaim =
+        new StubClaim(lookupService.lookupPrincipalByName(System.getProperty("user.name")));
+
+    PersistentWorker worker = new PersistentWorker(key, "worker-dir", meClaim);
+
+    worker.destroy();
+
+    Assert.assertTrue(meClaim.isReleased());
   }
 }

--- a/src/main/java/build/buildfarm/common/ClaimAcquirer.java
+++ b/src/main/java/build/buildfarm/common/ClaimAcquirer.java
@@ -1,0 +1,9 @@
+package build.buildfarm.common;
+
+import build.bazel.remote.execution.v2.Platform;
+import javax.annotation.Nullable;
+
+public interface ClaimAcquirer {
+  @Nullable
+  Claim acquireClaim(Platform platform);
+}

--- a/src/main/java/build/buildfarm/common/StubClaimAcquirer.java
+++ b/src/main/java/build/buildfarm/common/StubClaimAcquirer.java
@@ -1,0 +1,11 @@
+package build.buildfarm.common;
+
+import build.bazel.remote.execution.v2.Platform;
+import javax.annotation.Nullable;
+
+public class StubClaimAcquirer implements ClaimAcquirer {
+  @Override
+  public @Nullable Claim acquireClaim(Platform platform) {
+    return null;
+  }
+}

--- a/src/main/java/build/buildfarm/worker/WorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/WorkerContext.java
@@ -21,6 +21,7 @@ import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.DigestFunction;
 import build.bazel.remote.execution.v2.Directory;
 import build.bazel.remote.execution.v2.ExecutionStage;
+import build.buildfarm.common.ClaimAcquirer;
 import build.buildfarm.common.DigestUtil.ActionKey;
 import build.buildfarm.common.Poller;
 import build.buildfarm.common.Write;
@@ -42,7 +43,7 @@ import java.util.Map;
 import java.util.concurrent.Executor;
 import javax.annotation.Nullable;
 
-public interface WorkerContext {
+public interface WorkerContext extends ClaimAcquirer {
   interface IOResource extends AutoCloseable {
     @Override
     void close() throws IOException;

--- a/src/main/java/build/buildfarm/worker/persistent/BUILD
+++ b/src/main/java/build/buildfarm/worker/persistent/BUILD
@@ -15,6 +15,7 @@ java_library(
         "//src/main/java/build/buildfarm/worker/util",
         "//src/main/protobuf/build/buildfarm/v1test:buildfarm_java_proto",
         "@maven//:com_google_api_grpc_proto_google_common_protos",
+        "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:com_google_protobuf_protobuf_java_util",

--- a/src/main/java/build/buildfarm/worker/persistent/PersistentExecutor.java
+++ b/src/main/java/build/buildfarm/worker/persistent/PersistentExecutor.java
@@ -46,9 +46,6 @@ import persistent.bazel.client.WorkerKey;
  */
 @Log
 public class PersistentExecutor {
-  private static final ProtoCoordinator coordinator =
-      ProtoCoordinator.ofCommonsPool(getMaxWorkersPerKey());
-
   // TODO load from config (i.e. {worker_root}/persistent)
   public static final Path defaultWorkRootsDir = Path.of("/tmp/worker/persistent/");
 
@@ -60,21 +57,10 @@ public class PersistentExecutor {
 
   private static final String SCALAC_EXEC_NAME = "Scalac";
   private static final String JAVAC_EXEC_NAME = "JavaBuilder";
+  private final ProtoCoordinator coordinator;
 
-  // How many workers can exist at once for a given WorkerKey
-  // There may be multiple WorkerKeys per mnemonic,
-  //  e.g. if builds are run with different tool fingerprints
-  private static final int defaultMaxWorkersPerKey = 6;
-
-  private static int getMaxWorkersPerKey() {
-    try {
-      return Integer.parseInt(System.getenv("BUILDFARM_MAX_WORKERS_PER_KEY"));
-    } catch (Exception ignored) {
-      log.info(
-          "Could not get env var BUILDFARM_MAX_WORKERS_PER_KEY; defaulting to "
-              + defaultMaxWorkersPerKey);
-    }
-    return defaultMaxWorkersPerKey;
+  public PersistentExecutor(ProtoCoordinator coordinator) {
+    this.coordinator = coordinator;
   }
 
   /**
@@ -98,7 +84,7 @@ public class PersistentExecutor {
    * @param resultBuilder
    * @return
    */
-  public static Code runOnPersistentWorker(
+  public Code runOnPersistentWorker(
       WorkFilesContext context,
       String operationName,
       ImmutableList<String> argsList,

--- a/src/main/java/build/buildfarm/worker/persistent/WorkerInputs.java
+++ b/src/main/java/build/buildfarm/worker/persistent/WorkerInputs.java
@@ -20,7 +20,9 @@ import com.google.devtools.build.lib.worker.WorkerProtocol.Input;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.attribute.UserPrincipal;
 import java.util.List;
+import javax.annotation.Nullable;
 import lombok.extern.java.Log;
 
 @Log
@@ -65,9 +67,9 @@ public class WorkerInputs {
     return newRoot.resolve(opRoot.relativize(input));
   }
 
-  public void copyInputFile(Path from, Path to) throws IOException {
+  public void copyInputFile(Path from, Path to, @Nullable UserPrincipal owner) throws IOException {
     checkFileIsInput("copyInputFile()", from);
-    FileAccessUtils.copyFile(from, to);
+    FileAccessUtils.copyFile(from, to, owner);
   }
 
   public void deleteInputFileIfExists(Path workerExecRoot, Path opPathInput) throws IOException {

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -293,8 +293,8 @@ class ShardWorkerContext implements WorkerContext {
   }
 
   // FIXME make OwnedClaim with owner
-  // how will this play out with persistent workers, should we have one per user?
-  private @Nullable Claim acquireClaim(Platform platform) {
+  @Override
+  public @Nullable Claim acquireClaim(Platform platform) {
     // expand platform requirements with exec owner
     if (provideOwnedClaim) {
       platform = platform.toBuilder().addProperties(EXEC_OWNER_PROPERTY).build();

--- a/src/test/java/build/buildfarm/worker/StubWorkerContext.java
+++ b/src/test/java/build/buildfarm/worker/StubWorkerContext.java
@@ -21,6 +21,8 @@ import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.DigestFunction;
 import build.bazel.remote.execution.v2.Directory;
 import build.bazel.remote.execution.v2.ExecutionStage;
+import build.bazel.remote.execution.v2.Platform;
+import build.buildfarm.common.Claim;
 import build.buildfarm.common.DigestUtil.ActionKey;
 import build.buildfarm.common.Poller;
 import build.buildfarm.common.Write;
@@ -223,6 +225,11 @@ class StubWorkerContext implements WorkerContext {
 
   @Override
   public boolean shouldErrorOperationOnRemainingResources() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Claim acquireClaim(Platform platform) {
     throw new UnsupportedOperationException();
   }
 }

--- a/src/test/java/build/buildfarm/worker/persistent/ProtoCoordinatorTest.java
+++ b/src/test/java/build/buildfarm/worker/persistent/ProtoCoordinatorTest.java
@@ -17,6 +17,7 @@ package build.buildfarm.worker.persistent;
 import static com.google.common.truth.Truth.assertThat;
 
 import build.bazel.remote.execution.v2.Command;
+import build.buildfarm.common.StubClaimAcquirer;
 import build.buildfarm.v1test.Tree;
 import build.buildfarm.worker.util.WorkerTestUtils;
 import build.buildfarm.worker.util.WorkerTestUtils.TreeFile;
@@ -69,7 +70,7 @@ public class ProtoCoordinatorTest {
 
   @Test
   public void testProtoCoordinator() throws Exception {
-    ProtoCoordinator pc = ProtoCoordinator.ofCommonsPool(4);
+    ProtoCoordinator pc = ProtoCoordinator.ofCommonsPool(4, new StubClaimAcquirer());
 
     Path fsRoot = jimFsRoot();
     Path opRoot = fsRoot.resolve("opRoot");


### PR DESCRIPTION
My attempt at fixing #2289. This PR modifies `ProtoCoordinator` to acquire a claim when creating a `PersistentWorker`, which is released when the worker is destroyed.