### PR TITLE
fix(cfc): memory leak in LockMap

### DIFF
--- a/src/main/java/build/buildfarm/cas/BUILD
+++ b/src/main/java/build/buildfarm/cas/BUILD
@@ -21,6 +21,7 @@ java_library(
         "@googleapis//google/bytestream:bytestream_java_grpc",
         "@googleapis//google/bytestream:bytestream_java_proto",
         "@googleapis//google/rpc:rpc_java_proto",
+        "@maven//:com_github_ben_manes_caffeine_caffeine",
         "@maven//:com_github_jnr_jnr_ffi",
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_code_gson_gson",


### PR DESCRIPTION
This fixes a leak in the LockMap static instance. It was only creating objects and olding on to them forever.

This changes the implementation to use a Caffeine Cache with a weakValues wrapper. When the `SharedLock()` is out-of-scope and GC'd, it can be removed from the cache.

Fixes: #2274