### PR TITLE
Prevent matches when inputFetch is stalled

### DIFF
--- a/src/main/java/build/buildfarm/worker/InputFetchStage.java
+++ b/src/main/java/build/buildfarm/worker/InputFetchStage.java
@@ -14,8 +14,11 @@
 
 package build.buildfarm.worker;
 
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
 import io.prometheus.client.Gauge;
 import io.prometheus.client.Histogram;
+import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Logger;
 import javax.annotation.concurrent.GuardedBy;
 import lombok.extern.java.Log;
@@ -31,6 +34,7 @@ public class InputFetchStage extends SuperscalarPipelineStage {
           .name("input_fetch_stall_time_ms")
           .help("Input fetch stall time in ms.")
           .register();
+  private final ConcurrentMap<String, InputFetcher> inputFetchers;
 
   @GuardedBy("this")
   private int slotUsage;
@@ -43,6 +47,7 @@ public class InputFetchStage extends SuperscalarPipelineStage {
         output,
         error,
         workerContext.getInputFetchStageWidth());
+    inputFetchers = Maps.newConcurrentMap();
   }
 
   @Override
@@ -60,6 +65,7 @@ public class InputFetchStage extends SuperscalarPipelineStage {
   public void releaseInputFetcher(
       String operationName, long usecs, long stallUSecs, boolean success) {
     int size = removeAndRelease(operationName);
+    inputFetchers.remove(operationName);
     inputFetchTime.observe(usecs / 1000.0);
     inputFetchStallTime.observe(stallUSecs / 1000.0);
     complete(
@@ -75,10 +81,17 @@ public class InputFetchStage extends SuperscalarPipelineStage {
   }
 
   @Override
+  public boolean isStalled() {
+    // true iff any of the current fetchers are waiting to advance to execute
+    return Iterables.any(inputFetchers.values(), inputFetcher -> inputFetcher.isStalled());
+  }
+
+  @Override
   protected void iterate() throws InterruptedException {
     ExecutionContext executionContext = take();
     InputFetcher inputFetcher =
         new InputFetcher(workerContext, executionContext, this, pollerExecutor);
+    inputFetchers.put(executionContext.operation.getName(), inputFetcher);
 
     synchronized (this) {
       slotUsage++;

--- a/src/main/java/build/buildfarm/worker/InputFetcher.java
+++ b/src/main/java/build/buildfarm/worker/InputFetcher.java
@@ -304,6 +304,9 @@ public class InputFetcher implements Runnable {
     return stalled;
   }
 
+  @SuppressWarnings(
+      "PMD.UnusedLocalVariable") // PMD thinks that the try-with-resources is not used. See
+  // https://github.com/pmd/pmd/issues/5747
   private void proceedToOutput(Action action, Command command, Path execDir, Tree tree)
       throws InterruptedException {
     // switch poller to disable deadline
@@ -325,6 +328,7 @@ public class InputFetcher implements Runnable {
             .build();
     stalled = true;
     boolean claimed;
+    // PMD exemption false positive: unused variable
     try (StallState state = new StallState()) {
       claimed = owner.output().claim(fetchedExecutionContext);
     }

--- a/src/main/java/build/buildfarm/worker/InputFetcher.java
+++ b/src/main/java/build/buildfarm/worker/InputFetcher.java
@@ -63,6 +63,18 @@ public class InputFetcher implements Runnable {
   private final Executor pollerExecutor;
   private boolean success = false;
   private boolean polling = false;
+  private volatile boolean stalled = false;
+
+  private class StallState implements AutoCloseable {
+    StallState() {
+      stalled = true;
+    }
+
+    @Override
+    public void close() {
+      stalled = false;
+    }
+  }
 
   InputFetcher(
       WorkerContext workerContext,
@@ -288,6 +300,10 @@ public class InputFetcher implements Runnable {
     }
   }
 
+  public boolean isStalled() {
+    return stalled;
+  }
+
   private void proceedToOutput(Action action, Command command, Path execDir, Tree tree)
       throws InterruptedException {
     // switch poller to disable deadline
@@ -300,7 +316,6 @@ public class InputFetcher implements Runnable {
         Thread.currentThread()::interrupt,
         Deadline.after(10, DAYS),
         pollerExecutor);
-
     ExecutionContext fetchedExecutionContext =
         executionContext.toBuilder()
             .setExecDir(execDir)
@@ -308,7 +323,11 @@ public class InputFetcher implements Runnable {
             .setCommand(command)
             .setTree(tree)
             .build();
-    boolean claimed = owner.output().claim(fetchedExecutionContext);
+    stalled = true;
+    boolean claimed;
+    try (StallState state = new StallState()) {
+      claimed = owner.output().claim(fetchedExecutionContext);
+    }
     executionContext.poller.pause();
     if (claimed) {
       try {

--- a/src/main/java/build/buildfarm/worker/MatchStage.java
+++ b/src/main/java/build/buildfarm/worker/MatchStage.java
@@ -146,7 +146,7 @@ public class MatchStage extends PipelineStage {
   protected void iterate() throws InterruptedException {
     start(); // clear any previous operation
     // stop matching and picking up any works if the worker is in graceful shutdown.
-    if (inGracefulShutdown) {
+    if (inGracefulShutdown || output.isStalled()) {
       return;
     }
     Stopwatch stopwatch = Stopwatch.createStarted();

--- a/src/main/java/build/buildfarm/worker/PipelineStage.java
+++ b/src/main/java/build/buildfarm/worker/PipelineStage.java
@@ -43,6 +43,10 @@ public abstract class PipelineStage implements Runnable {
     this.error = error;
   }
 
+  public boolean isStalled() {
+    return false;
+  }
+
   protected void runInterruptible() throws InterruptedException {
     while (!output.isClosed() || isClaimed()) {
       iterate();


### PR DESCRIPTION
Meant to prevent taking on more work when exec could not handle it Generally, if a stage is stalled, versus saturated, getting more work to it is unlikely to be beneficial to the rest of the cluster or workload. Options for configuration:
  Time stuck in stalled (aggregate or individual per fetcher)
  Percentage additional work saturation (could be dynamic depending upon
  processing times)