### PR TITLE
Create valves with ShardWorkerContext control for stages

### DIFF
--- a/src/main/java/build/buildfarm/worker/InputFetchStage.java
+++ b/src/main/java/build/buildfarm/worker/InputFetchStage.java
@@ -88,6 +88,9 @@ public class InputFetchStage extends SuperscalarPipelineStage {
 
   @Override
   protected void iterate() throws InterruptedException {
+    if (!workerContext.isInputFetching()) {
+      return;
+    }
     ExecutionContext executionContext = take();
     InputFetcher inputFetcher =
         new InputFetcher(workerContext, executionContext, this, pollerExecutor);

--- a/src/main/java/build/buildfarm/worker/Pipeline.java
+++ b/src/main/java/build/buildfarm/worker/Pipeline.java
@@ -43,6 +43,10 @@ public class Pipeline {
     stageClosePriorities.put(stage, closePriority);
   }
 
+  public void interrupt(PipelineStage stage) {
+    stageThreads.get(stage).interrupt();
+  }
+
   public void start() {
     for (Thread stageThread : stageThreads.values()) {
       stageThread.start();
@@ -58,18 +62,6 @@ public class Pipeline {
       }
     }
     join(true);
-  }
-
-  /** Inform MatchStage to stop matching or picking up new Operations from queue. */
-  public void stopMatchingOperations() {
-    for (Map.Entry<PipelineStage, Thread> entry : stageThreads.entrySet()) {
-      PipelineStage stage = entry.getKey();
-      if (stage instanceof MatchStage matchStage) {
-        matchStage.prepareForGracefulShutdown();
-        entry.getValue().interrupt();
-        return;
-      }
-    }
   }
 
   /**

--- a/src/main/java/build/buildfarm/worker/WorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/WorkerContext.java
@@ -66,6 +66,18 @@ public interface WorkerContext {
       Deadline deadline,
       Executor executor);
 
+  boolean inGracefulShutdown();
+
+  boolean isMatching();
+
+  boolean isInputFetching();
+
+  boolean isExecuting();
+
+  boolean isReportingResults();
+
+  void prepareForGracefulShutdown();
+
   void match(MatchListener listener) throws InterruptedException;
 
   List<ExecutionPolicy> getExecutionPolicies(String name);

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -147,7 +147,6 @@ public final class Worker extends LoggingMain {
 
   private static BuildfarmConfigs configs = BuildfarmConfigs.getInstance();
 
-  private boolean inGracefulShutdown = false;
   private boolean isPaused = false;
 
   private WorkerInstance instance;
@@ -158,9 +157,12 @@ public final class Worker extends LoggingMain {
   private Path root;
   private ExecFileSystem execFileSystem;
   private Pipeline pipeline;
+  private PipelineStage matchStage;
+  private ShardWorkerContext context;
   private Backplane backplane;
   private LoadingCache<String, StubInstance> workerStubs;
   private AtomicBoolean released = new AtomicBoolean(true);
+  private AtomicBoolean shutdownInitiated = new AtomicBoolean(false);
 
   /**
    * The method will prepare the worker for graceful shutdown when the worker is ready. Note on
@@ -173,11 +175,10 @@ public final class Worker extends LoggingMain {
           "Graceful Shutdown is not enabled. Worker is shutting down without finishing executions"
               + " in progress.");
     } else {
-      inGracefulShutdown = true;
       log.info(
           "Graceful Shutdown - The current worker will not be registered again and should be"
               + " shutdown gracefully!");
-      pipeline.stopMatchingOperations();
+      context.prepareForGracefulShutdown();
       int scanRate = 30; // check every 30 seconds
       int timeWaited = 0;
       int timeOut = configs.getWorker().getGracefulShutdownSeconds();
@@ -617,7 +618,7 @@ public final class Worker extends LoggingMain {
                   if (pausedFile.exists() && !isPaused) {
                     isPaused = true;
                     log.log(Level.INFO, "The current worker is paused from taking on new work!");
-                    pipeline.stopMatchingOperations();
+                    context.prepareForGracefulShutdown();
                     workerPausedMetric.inc();
                   }
                 } catch (Exception e) {
@@ -629,7 +630,7 @@ public final class Worker extends LoggingMain {
               void registerIfExpired() {
                 long now = System.currentTimeMillis();
                 if (now >= workerRegistrationExpiresAt
-                    && !inGracefulShutdown
+                    && !context.inGracefulShutdown()
                     && !isWorkerPausedFromNewWork()) {
                   // worker must be registered to match
                   addWorker(nextRegistration(now));
@@ -757,7 +758,7 @@ public final class Worker extends LoggingMain {
       writer = new LocalCasWriter(execFileSystem);
     }
 
-    ShardWorkerContext context =
+    context =
         new ShardWorkerContext(
             configs.getWorker().getPublicName(),
             Duration.newBuilder().setSeconds(configs.getWorker().getOperationPollPeriod()).build(),
@@ -816,16 +817,36 @@ public final class Worker extends LoggingMain {
 
   private void awaitTermination() throws InterruptedException {
     pipeline.join();
-    server.awaitTermination();
+    if (server != null && !server.isTerminated()) {
+      int retries = 5;
+      while (retries > 0) {
+        if (shutdownInitiated.get()) {
+          server.shutdown();
+          retries--;
+        }
+        if (server.awaitTermination(shutdownWaitTimeInSeconds, SECONDS)) {
+          retries = 1;
+          break;
+        }
+      }
+      if (retries == 0) {
+        server.shutdownNow();
+        server.awaitTermination();
+      }
+    }
   }
 
   public void initiateShutdown() {
+    if (context != null) {
+      context.prepareForGracefulShutdown();
+    }
     if (pipeline != null) {
-      pipeline.stopMatchingOperations();
+      pipeline.interrupt(matchStage);
     }
     if (server != null) {
       server.shutdown();
     }
+    shutdownInitiated.set(true);
   }
 
   private synchronized void awaitRelease() throws InterruptedException {

--- a/src/test/java/build/buildfarm/worker/InputFetchStageTest.java
+++ b/src/test/java/build/buildfarm/worker/InputFetchStageTest.java
@@ -83,6 +83,7 @@ public class InputFetchStageTest {
             .build();
 
     WorkerContext workerContext = mock(WorkerContext.class);
+    when(workerContext.isInputFetching()).thenReturn(true);
     when(workerContext.getInputFetchStageWidth()).thenReturn(1);
     when(workerContext.getInputFetchDeadline()).thenReturn(60);
     // inspire empty argument list in Command resulting in null
@@ -123,6 +124,7 @@ public class InputFetchStageTest {
             any(Runnable.class),
             any(Deadline.class),
             any(Executor.class));
+    verify(workerContext, times(2)).isInputFetching();
     verifyNoMoreInteractions(workerContext);
     ExecutionContext executionContext = error.getExecutionContexts().getFirst();
     assertThat(executionContext).isEqualTo(badContext);

--- a/src/test/java/build/buildfarm/worker/StubWorkerContext.java
+++ b/src/test/java/build/buildfarm/worker/StubWorkerContext.java
@@ -65,6 +65,36 @@ class StubWorkerContext implements WorkerContext {
   }
 
   @Override
+  public boolean inGracefulShutdown() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean isMatching() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean isInputFetching() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean isExecuting() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean isReportingResults() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void prepareForGracefulShutdown() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public void match(MatchListener listener) throws InterruptedException {
     throw new UnsupportedOperationException();
   }


### PR DESCRIPTION
pauseMatch/InputFetch/Execute/ReportResult holds respective stages for successive action processing.
inGracefulShutdown prevents further matches and forces all subsequent stage valves open, overriding any pause
inGracefulShutdown, relocated to worker context for centralized control.