### PR TITLE
chore: Apply license headers for *.sh

### DIFF
--- a/.bazelci/cache_test.sh
+++ b/.bazelci/cache_test.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2022-2025 The Buildfarm Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # This is a CI integation test for a typical eployment of buildfarm.
 # It ensures that the buildfarm services can startup and function as expected given PR changes.
 # All of the needed buildfarm services are initialized (redis, server, worker).

--- a/.bazelci/docker_unit_test.sh
+++ b/.bazelci/docker_unit_test.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2021-2025 The Buildfarm Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # This is to run buildfarm's unit tests from within a docker container
 
 # Build a container for unit tests and run them

--- a/.bazelci/format.sh
+++ b/.bazelci/format.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+# Copyright 2020-2025 The Buildfarm Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Run from the root of repository.
 # This script will format all of the java source files.
 # Use the flag --check if you want the script to fail when formatting is not correct.

--- a/.bazelci/integration_test.sh
+++ b/.bazelci/integration_test.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2021-2025 The Buildfarm Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # This is a CI integation test for a typical deployment of buildfarm.
 # It ensures that the buildfarm services can startup and function as expected given PR changes.
 # All of the needed buildfarm services are initialized (redis, server, worker).

--- a/.bazelci/package_name_check.sh
+++ b/.bazelci/package_name_check.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2021-2025 The Buildfarm Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Run this from the root of repository.
 # The script will check that each java source file has the a package name that matches its file path.
 # This is done for more than just consistency. Bazel's code coverage seems to exclude files when the package name does not match.

--- a/.bazelci/redis_unit_tests.sh
+++ b/.bazelci/redis_unit_tests.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2022-2025 The Buildfarm Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Typically our redis implementations are mocked.
 # However this runs unit tests that interact directly with redis.
 

--- a/.bazelci/run_abseil_test.sh
+++ b/.bazelci/run_abseil_test.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2021-2025 The Buildfarm Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Test bazel targets with buildfarm
 cd src/test/abseil;
 ../../../bazel test --jobs=25 $1 --noenable_bzlmod --test_output=errors --incompatible_enable_cc_toolchain_resolution --verbose_failures --verbose_explanations --test_tag_filters=-benchmark --remote_executor=grpc://localhost:8980 @com_google_absl//... -- -@com_google_absl//absl/time/...

--- a/.bazelci/run_checkstyle.sh
+++ b/.bazelci/run_checkstyle.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2023-2025 The Buildfarm Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Run from the root of repository.
 # This script will perform static analysis on all of the java source files.
 

--- a/.bazelci/run_generative_cc_many_double_test.sh
+++ b/.bazelci/run_generative_cc_many_double_test.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2022-2025 The Buildfarm Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Build bazel targets with buildfarm
 cd src/test/many;
 MANY_CC_BINARIES=50 MANY_CC_LIBRARIES=2 MANY_CC_LIBRARY_SOURCES=1 ../../../bazel build :cc --remote_executor=grpc://localhost:8980 $1

--- a/.bazelci/run_generative_cc_many_test.sh
+++ b/.bazelci/run_generative_cc_many_test.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2021-2025 The Buildfarm Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -o xtrace
 
 # Build bazel targets with buildfarm

--- a/.bazelci/run_server_test.sh
+++ b/.bazelci/run_server_test.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+# Copyright 2022-2025 The Buildfarm Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # Start redis container
 docker run -d --rm --name buildfarm-redis --network host redis:7.2.4 --bind localhost

--- a/.bazelci/static_analyze.sh
+++ b/.bazelci/static_analyze.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2021-2025 The Buildfarm Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Run from the root of repository.
 # This script will perform static analysis on all of the java source files.
 

--- a/.bazelci/test_buildfarm_container.sh
+++ b/.bazelci/test_buildfarm_container.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2021-2025 The Buildfarm Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -e
 set -o pipefail
 

--- a/.bazelci/unused_deps.sh
+++ b/.bazelci/unused_deps.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2021-2025 The Buildfarm Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Run from the root of repository.
 # This script will remove any unused java dependencies
 # Use the flag --check if you want the script to fail when the dependencies not correct.

--- a/delay.sh
+++ b/delay.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+# Copyright 2021-2025 The Buildfarm Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Delay running a program by sleeping.
 # If you are also skipping sleep syscalls, this will result in timeshifting you into the future.
 # This can help catch problems by tricking the program into thinking its future time.

--- a/examples/development-redis-cluster.sh
+++ b/examples/development-redis-cluster.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+# Copyright 2021-2025 The Buildfarm Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 # First, start six Redis instances using this script:
 #   ./development-redis-cluster.sh 0

--- a/generate_coverage.sh
+++ b/generate_coverage.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+# Copyright 2020-2025 The Buildfarm Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Run on specifc test targets via: ./generate_coverage.sh <target>
 # Script can be run without <target> to get coverage on all tests.
 

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -3,7 +3,7 @@ headerPath = "ci/license-header.txt"
 includes = [
     "*.c",
     # "*.java", # TODO
-    # "*.sh", # TODO
+    "*.sh",
 ]
 
 [git]

--- a/macos-wrapper.sh
+++ b/macos-wrapper.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+# Copyright 2022-2025 The Buildfarm Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # An Apple specific Apple execution wrapper - mainly to set SDKROOT and
 # DEVELOPER_DIR.
 # There is no enforcement of where Xcode.app is installed locally or remote so


### PR DESCRIPTION
Apply license headers for `*.sh` with:


```sh
> hawkeye format
```

https://github.com/korandoru/hawkeye