### PR TITLE
Stop printing stack trace for download error

### DIFF
--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -2042,8 +2042,10 @@ public abstract class CASFileCache implements ContentAddressableStorage {
       out.cancel();
       log.log(
           Level.WARNING,
-          format("error downloading %s", DigestUtil.toString(digest)),
-          e); // prevent burial by early end of stream during close
+          format(
+              "error downloading %s: %s",
+              DigestUtil.toString(digest),
+              e.getMessage())); // prevent burial by early end of stream during close
       throw e;
     }
     log.log(Level.FINER, format("download of %s complete", DigestUtil.toString(digest)));


### PR DESCRIPTION
This is a warning, which shows up frequently, filling up logs. As it is a warning and not a severe error we should not print a stack trace with it. This PR removes the stack trace output.

Before:
```
WARNING: error downloading 1f45849402450bd118279c07eba1777ba2d5ab8e/64
java.nio.file.NoSuchFileException: 1f45849402450bd118279c07eba1777ba2d5ab8e/64
at build.buildfarm.instance.shard.RemoteInputStreamFactory$1.onFailure(RemoteInputStreamFactory.java:266)
at build.buildfarm.instance.shard.ServerInstance$WorkersCallback.onSuccess(ServerInstance.java:1408)
at build.buildfarm.instance.shard.ServerInstance$WorkersCallback.onSuccess(ServerInstance.java:1398)
at com.google.common.util.concurrent.Futures$CallbackListener.run(Futures.java:1132)
at com.google.common.util.concurrent.DirectExecutor.execute(DirectExecutor.java:30)
at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:1004)
at com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:767)
at com.google.common.util.concurrent.AbstractFuture.set(AbstractFuture.java:491)
at com.google.common.util.concurrent.AbstractTransformFuture$TransformFuture.setResult(AbstractTransformFuture.java:260)
at com.google.common.util.concurrent.AbstractTransformFuture.run(AbstractTransformFuture.java:172)
at com.google.common.util.concurrent.DirectExecutor.execute(DirectExecutor.java:30)
at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:1004)
at com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:767)
at com.google.common.util.concurrent.AbstractFuture.set(AbstractFuture.java:491)
at com.google.common.util.concurrent.AbstractTransformFuture$TransformFuture.setResult(AbstractTransformFuture.java:260)
at com.google.common.util.concurrent.AbstractTransformFuture.run(AbstractTransformFuture.java:172)
at com.google.common.util.concurrent.DirectExecutorService.execute(DirectExecutorService.java:52)
at com.google.common.util.concurrent.MoreExecutors.lambda$rejectionPropagatingExecutor$2(MoreExecutors.java:1032)
at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:1004)
at com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:767)
at com.google.common.util.concurrent.AbstractFuture.set(AbstractFuture.java:491)
at com.google.common.util.concurrent.SettableFuture.set(SettableFuture.java:48)
at build.buildfarm.instance.shard.Util$1.complete(Util.java:121)
at build.buildfarm.instance.shard.Util$1.onSuccess(Util.java:134)
at build.buildfarm.instance.shard.Util$1.onSuccess(Util.java:118)
at build.buildfarm.instance.shard.Util$2.onSuccess(Util.java:157)
at build.buildfarm.instance.shard.Util$2.onSuccess(Util.java:154)
at build.buildfarm.instance.shard.Util$3.onSuccess(Util.java:194)
at build.buildfarm.instance.shard.Util$3.onSuccess(Util.java:185)
at com.google.common.util.concurrent.Futures$CallbackListener.run(Futures.java:1132)
at com.google.common.util.concurrent.DirectExecutor.execute(DirectExecutor.java:30)
at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:1004)
at com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:767)
at com.google.common.util.concurrent.AbstractFuture.set(AbstractFuture.java:491)
at com.google.common.util.concurrent.AbstractTransformFuture$TransformFuture.setResult(AbstractTransformFuture.java:260)
at com.google.common.util.concurrent.AbstractTransformFuture.run(AbstractTransformFuture.java:172)
at com.google.common.util.concurrent.DirectExecutor.execute(DirectExecutor.java:30)
at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:1004)
at com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:767)
at com.google.common.util.concurrent.AbstractFuture.set(AbstractFuture.java:491)
at io.grpc.stub.ClientCalls$GrpcFuture.set(ClientCalls.java:663)
at io.grpc.stub.ClientCalls$UnaryStreamToFuture.onClose(ClientCalls.java:636)
at io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:565)
at io.grpc.internal.ClientCallImpl.access$100(ClientCallImpl.java:72)
at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInternal(ClientCallImpl.java:733)
at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInContext(ClientCallImpl.java:714)
at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
at java.base/java.lang.Thread.run(Thread.java:1583)
```
After:
```
WARNING: error downloading 1f45849402450bd118279c07eba1777ba2d5ab8e/64: 1f45849402450bd118279c07eba1777ba2d5ab8e/64
```