### PR TITLE
refactor(bazel): reduce unnecessary build dependencies

### DIFF
--- a/persistentworkers/src/main/java/persistent/common/BUILD
+++ b/persistentworkers/src/main/java/persistent/common/BUILD
@@ -6,7 +6,6 @@ java_library(
     plugins = ["//src/main/java/build/buildfarm/common:lombok"],
     visibility = ["//visibility:public"],
     deps = [
-        "//persistentworkers/src/main/java/persistent/common/util",
         "//persistentworkers/src/main/protobuf:worker_protocol_java_proto",
         "@buildfarm_maven//:com_github_pcj_google_options",
         "@buildfarm_maven//:com_google_guava_guava",

--- a/persistentworkers/src/test/java/persistent/common/BUILD
+++ b/persistentworkers/src/test/java/persistent/common/BUILD
@@ -7,7 +7,6 @@ java_test(
     deps = [
         "//persistentworkers/src/main/java/persistent/common:persistent-common",
         "//persistentworkers/src/main/protobuf:worker_protocol_java_proto",
-        "//persistentworkers/src/test/java/persistent/testutil",
         "@buildfarm_maven//:com_google_truth_truth",
         "@buildfarm_maven//:commons_io_commons_io",
         "@buildfarm_maven//:org_mockito_mockito_core",

--- a/src/main/java/build/buildfarm/actioncache/BUILD
+++ b/src/main/java/build/buildfarm/actioncache/BUILD
@@ -9,8 +9,6 @@ java_library(
         "//src/main/java/build/buildfarm/backplane",
         "//src/main/java/build/buildfarm/common",
         "//src/main/java/build/buildfarm/common/config",
-        "//src/main/java/build/buildfarm/common/resources",
-        "//third_party/remote-apis:build_bazel_remote_execution_v2_remote_execution_java_grpc",
         "@buildfarm_maven//:com_github_ben_manes_caffeine_caffeine",
         "@buildfarm_maven//:com_google_guava_guava",
         "@buildfarm_maven//:com_google_protobuf_protobuf_java",

--- a/src/main/java/build/buildfarm/backplane/BUILD
+++ b/src/main/java/build/buildfarm/backplane/BUILD
@@ -7,7 +7,6 @@ java_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/main/java/build/buildfarm/common",
-        "//src/main/java/build/buildfarm/instance",
         "//src/main/java/build/buildfarm/worker/resources",
         "//src/main/protobuf/build/buildfarm/v1test:buildfarm_java_proto",
         "@buildfarm_maven//:com_google_code_findbugs_jsr305",

--- a/src/main/java/build/buildfarm/common/BUILD
+++ b/src/main/java/build/buildfarm/common/BUILD
@@ -54,8 +54,6 @@ java_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/main/java/build/buildfarm/common",
-        "//src/main/java/build/buildfarm/common/config",
-        "//src/main/java/build/buildfarm/common/resources",
         "//src/main/java/build/buildfarm/common/resources:resource_java_proto",
         "//src/main/protobuf/build/buildfarm/v1test:buildfarm_java_proto",
         "@buildfarm_maven//:com_github_jnr_jnr_constants",

--- a/src/main/java/build/buildfarm/tools/BUILD
+++ b/src/main/java/build/buildfarm/tools/BUILD
@@ -110,7 +110,6 @@ java_binary(
     main_class = "build.buildfarm.tools.Cat",
     visibility = ["//visibility:public"],
     deps = [
-        ":worker-profiler-printer",
         "//src/main/java/build/buildfarm/common",
         "//src/main/java/build/buildfarm/common/grpc",
         "//src/main/java/build/buildfarm/common/resources",
@@ -142,13 +141,9 @@ java_binary(
     deps = [
         ":worker-profiler-printer",
         "//src/main/java/build/buildfarm/common",
-        "//src/main/java/build/buildfarm/common/config",
         "//src/main/java/build/buildfarm/common/grpc",
-        "//src/main/java/build/buildfarm/common/redis",
         "//src/main/java/build/buildfarm/instance",
-        "//src/main/java/build/buildfarm/instance/shard",
         "//src/main/java/build/buildfarm/instance/stub",
-        "//src/main/java/build/buildfarm/worker/shard",
         "//src/main/protobuf/build/buildfarm/v1test:buildfarm_java_proto",
         "@buildfarm_maven//:com_github_pcj_google_options",
         "@buildfarm_maven//:com_google_guava_guava",
@@ -172,7 +167,6 @@ java_binary(
     main_class = "build.buildfarm.tools.Ac",
     visibility = ["//visibility:public"],
     deps = [
-        ":worker-profiler-printer",
         "//src/main/java/build/buildfarm/common",
         "//src/main/java/build/buildfarm/common/grpc",
         "//src/main/java/build/buildfarm/instance",
@@ -280,13 +274,6 @@ java_library(
     srcs = ["WorkerProfilePrinter.java"],
     visibility = ["//visibility:public"],
     deps = [
-        "//src/main/java/build/buildfarm/common",
-        "//src/main/java/build/buildfarm/common/config",
-        "//src/main/java/build/buildfarm/common/redis",
-        "//src/main/java/build/buildfarm/instance",
-        "//src/main/java/build/buildfarm/instance/shard",
-        "//src/main/java/build/buildfarm/instance/stub",
-        "//src/main/java/build/buildfarm/worker/shard",
         "//src/main/protobuf/build/buildfarm/v1test:buildfarm_java_proto",
         "@buildfarm_maven//:com_github_pcj_google_options",
         "@buildfarm_maven//:com_google_guava_guava",

--- a/src/main/java/build/buildfarm/worker/persistent/BUILD
+++ b/src/main/java/build/buildfarm/worker/persistent/BUILD
@@ -8,7 +8,6 @@ java_library(
     deps = [
         "//persistentworkers/src/main/java/persistent/bazel:bazel-persistent-workers",
         "//persistentworkers/src/main/java/persistent/common:persistent-common",
-        "//persistentworkers/src/main/java/persistent/common/util",
         "//persistentworkers/src/main/protobuf:worker_protocol_java_proto",
         "//src/main/java/build/buildfarm/common",
         "//src/main/java/build/buildfarm/worker/resources",

--- a/src/main/java/build/buildfarm/worker/resources/BUILD
+++ b/src/main/java/build/buildfarm/worker/resources/BUILD
@@ -8,7 +8,6 @@ java_library(
     deps = [
         "//src/main/java/build/buildfarm/common",
         "//src/main/java/build/buildfarm/common/config",
-        "//src/main/java/build/buildfarm/instance",
         "//src/main/protobuf/build/buildfarm/v1test:buildfarm_java_proto",
         "@buildfarm_maven//:com_google_code_findbugs_jsr305",
         "@buildfarm_maven//:com_google_code_gson_gson",

--- a/src/main/java/build/buildfarm/worker/util/BUILD
+++ b/src/main/java/build/buildfarm/worker/util/BUILD
@@ -7,9 +7,6 @@ java_library(
     deps = [
         "//persistentworkers/src/main/protobuf:worker_protocol_java_proto",
         "//src/main/java/build/buildfarm/common",
-        "//src/main/java/build/buildfarm/instance",
-        "//src/main/java/build/buildfarm/instance/stub",
-        "//src/main/java/build/buildfarm/worker/resources",
         "//src/main/protobuf/build/buildfarm/v1test:buildfarm_java_proto",
         "@buildfarm_maven//:com_google_code_gson_gson",
         "@buildfarm_maven//:com_google_guava_guava",

--- a/src/test/java/build/buildfarm/common/io/BUILD
+++ b/src/test/java/build/buildfarm/common/io/BUILD
@@ -7,7 +7,6 @@ java_test(
     deps = [
         "//src/main/java/build/buildfarm/common",
         "//src/main/java/build/buildfarm/common/base",
-        "//src/main/java/build/buildfarm/common/grpc",
         "//src/test/java/build/buildfarm:test_runner",
         "@buildfarm_maven//:com_google_guava_guava",
         "@buildfarm_maven//:com_google_jimfs_jimfs",
@@ -20,7 +19,6 @@ java_test(
         "@buildfarm_maven//:io_grpc_grpc_testing",
         "@buildfarm_maven//:org_apache_commons_commons_compress",
         "@buildfarm_maven//:org_mockito_mockito_core",
-        "@googleapis//google/bytestream:bytestream_java_grpc",
         "@googleapis//google/bytestream:bytestream_java_proto",
     ],
 )

--- a/src/test/java/build/buildfarm/worker/persistent/BUILD
+++ b/src/test/java/build/buildfarm/worker/persistent/BUILD
@@ -8,12 +8,9 @@ java_test(
     deps = [
         "//persistentworkers/src/main/java/persistent/bazel:bazel-persistent-workers",
         "//persistentworkers/src/main/java/persistent/common:persistent-common",
-        "//persistentworkers/src/main/java/persistent/common/util",
         "//persistentworkers/src/main/protobuf:worker_protocol_java_proto",
         "//src/main/java/build/buildfarm/common",
         "//src/main/java/build/buildfarm/common/config",
-        "//src/main/java/build/buildfarm/instance",
-        "//src/main/java/build/buildfarm/worker",
         "//src/main/java/build/buildfarm/worker/persistent",
         "//src/main/java/build/buildfarm/worker/resources",
         "//src/main/protobuf/build/buildfarm/v1test:buildfarm_java_proto",

--- a/src/test/java/build/buildfarm/worker/util/BUILD
+++ b/src/test/java/build/buildfarm/worker/util/BUILD
@@ -8,9 +8,7 @@ java_library(
     visibility = ["//src/test/java:__subpackages__"],
     deps = [
         "//persistentworkers/src/main/protobuf:worker_protocol_java_proto",
-        "//src/main/java/build/buildfarm/cas",
         "//src/main/java/build/buildfarm/common",
-        "//src/main/java/build/buildfarm/common/config",
         "//src/main/java/build/buildfarm/worker/util",
         "//src/main/protobuf/build/buildfarm/v1test:buildfarm_java_proto",
         "//src/test/java/build/buildfarm:test_runner",
@@ -38,11 +36,8 @@ java_test(
     srcs = glob(["*Test.java"]),
     test_class = "build.buildfarm.AllTests",
     deps = [
-        ":worker_test_utils",
         "//persistentworkers/src/main/protobuf:worker_protocol_java_proto",
-        "//src/main/java/build/buildfarm/cas",
         "//src/main/java/build/buildfarm/common",
-        "//src/main/java/build/buildfarm/common/config",
         "//src/main/java/build/buildfarm/worker/util",
         "//src/main/protobuf/build/buildfarm/v1test:buildfarm_java_proto",
         "//src/test/java/build/buildfarm:test_runner",


### PR DESCRIPTION
We've identified many redundant dependencies in bazel build scripts and refactored them, as part of a research project on dependency reduction.

Feel free to leave feedback, suggest improvements, or directly edit this PR.

Thanks for your support!