### PR TITLE
fix: truncate getTree pages to stay under grpc message size limit (#2483)

### DIFF
--- a/src/main/java/build/buildfarm/instance/server/NodeInstance.java
+++ b/src/main/java/build/buildfarm/instance/server/NodeInstance.java
@@ -52,6 +52,7 @@ import build.bazel.remote.execution.v2.ExecuteResponse;
 import build.bazel.remote.execution.v2.ExecutionCapabilities;
 import build.bazel.remote.execution.v2.ExecutionStage;
 import build.bazel.remote.execution.v2.FileNode;
+import build.bazel.remote.execution.v2.GetTreeResponse;
 import build.bazel.remote.execution.v2.OutputDirectory;
 import build.bazel.remote.execution.v2.OutputFile;
 import build.bazel.remote.execution.v2.Platform;
@@ -107,6 +108,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import com.google.longrunning.Operation;
 import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.CodedOutputStream;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Parser;
 import com.google.rpc.Code;
@@ -159,6 +161,17 @@ public abstract class NodeInstance extends InstanceBase {
   protected final OperationsMap completedOperations;
   protected final Map<Digest, ByteString> activeBlobWrites;
   protected final boolean ensureOutputsPresent;
+
+  // The default grpc max message size (4 MiB). A getTree page is truncated to stay below this so
+  // that the resulting GetTreeResponse does not exceed the grpc per-message byte limit. A buffer is
+  // reserved within the page builder below to leave room for the response envelope (nextPageToken).
+  private static final int DEFAULT_GET_TREE_MAX_MESSAGE_SIZE_BYTES = 4 * 1024 * 1024;
+
+  // Reserve a small portion of the message budget for the GetTreeResponse fields surrounding the
+  // repeated directories (notably nextPageToken) and grpc framing slack.
+  private static final int GET_TREE_RESPONSE_OVERHEAD_BYTES = 1024;
+
+  private int getTreeMaxMessageSizeBytes = DEFAULT_GET_TREE_MAX_MESSAGE_SIZE_BYTES;
 
   public static final String ACTION_INPUT_ROOT_DIRECTORY_PATH = "";
 
@@ -622,6 +635,11 @@ public abstract class NodeInstance extends InstanceBase {
   protected abstract TokenizableIterator<DirectoryEntry> createTreeIterator(
       String reason, build.buildfarm.v1test.Digest rootDigest, String pageToken);
 
+  @VisibleForTesting
+  void setGetTreeMaxMessageSizeBytes(int getTreeMaxMessageSizeBytes) {
+    this.getTreeMaxMessageSizeBytes = getTreeMaxMessageSizeBytes;
+  }
+
   @Override
   public String getTree(
       build.buildfarm.v1test.Digest rootDigest, int pageSize, String pageToken, Tree.Builder tree) {
@@ -636,17 +654,45 @@ public abstract class NodeInstance extends InstanceBase {
 
     TokenizableIterator<DirectoryEntry> iter = createTreeIterator("getTree", rootDigest, pageToken);
 
+    // The page budget for the serialized directories within the GetTreeResponse. We always emit at
+    // least one directory per page to guarantee forward progress, even if that directory alone
+    // exceeds the budget (a pathological single oversized directory cannot be split here).
+    int pageBudgetBytes = getTreeMaxMessageSizeBytes - GET_TREE_RESPONSE_OVERHEAD_BYTES;
+    int pageBytes = 0;
+    boolean directoryAdded = false;
+
+    // The page token resuming at the current entry. Captured before advancing the iterator so that,
+    // if the entry does not fit, we can return a token that re-yields it as the first entry of the
+    // next page - losing and duplicating nothing.
+    String resumeToken = iter.toNextPageToken();
+
     while (iter.hasNext() && pageSize != 0) {
       DirectoryEntry entry = iter.next();
       Directory directory = entry.getDirectory();
       // If part of the tree is missing from the CAS, the server will return the
       // portion present and omit the rest.
       if (directory != null) {
+        // The contribution of this directory to the serialized GetTreeResponse - a repeated
+        // Directory field: the message bytes plus its tag and length-delimiter.
+        int directorySize = directory.getSerializedSize();
+        int entryBytes =
+            CodedOutputStream.computeTagSize(GetTreeResponse.DIRECTORIES_FIELD_NUMBER)
+                + CodedOutputStream.computeUInt32SizeNoTag(directorySize)
+                + directorySize;
+        // Stop before overflowing the page, but never produce an empty page: the first directory is
+        // always emitted so the walk makes progress. The resume token points at this entry, so it
+        // will lead the next page.
+        if (directoryAdded && pageBytes + entryBytes > pageBudgetBytes) {
+          return resumeToken;
+        }
         tree.putDirectories(entry.getDigest().getHash(), directory);
+        pageBytes += entryBytes;
+        directoryAdded = true;
         if (pageSize > 0) {
           pageSize--;
         }
       }
+      resumeToken = iter.toNextPageToken();
     }
     return iter.toNextPageToken();
   }

--- a/src/test/java/build/buildfarm/instance/server/NodeInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/server/NodeInstanceTest.java
@@ -42,6 +42,7 @@ import build.bazel.remote.execution.v2.Directory;
 import build.bazel.remote.execution.v2.DirectoryNode;
 import build.bazel.remote.execution.v2.ExecutionPolicy;
 import build.bazel.remote.execution.v2.FileNode;
+import build.bazel.remote.execution.v2.GetTreeResponse;
 import build.bazel.remote.execution.v2.OutputDirectory;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import build.bazel.remote.execution.v2.ResultsCachePolicy;
@@ -54,6 +55,7 @@ import build.buildfarm.common.DigestUtil;
 import build.buildfarm.common.DigestUtil.ActionKey;
 import build.buildfarm.common.DigestUtil.HashFunction;
 import build.buildfarm.common.TokenizableIterator;
+import build.buildfarm.common.TreeIterator;
 import build.buildfarm.common.TreeIterator.DirectoryEntry;
 import build.buildfarm.common.Watcher;
 import build.buildfarm.common.Write;
@@ -83,7 +85,9 @@ import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Stack;
 import java.util.UUID;
@@ -232,6 +236,153 @@ public class NodeInstanceTest {
         Watcher watcher) {
       throw new UnsupportedOperationException();
     }
+  }
+
+  /**
+   * A NodeInstance backed by an in-memory directory map, exposing getTree over a real TreeIterator.
+   * Used to exercise page-size and message-size limiting of getTree.
+   */
+  static class TreeServerInstance extends DummyServerInstance {
+    private final Map<Digest, Directory> directoriesIndex;
+    private final int maxPageSize;
+
+    TreeServerInstance(Map<Digest, Directory> directoriesIndex, int maxPageSize) {
+      this.directoriesIndex = directoriesIndex;
+      this.maxPageSize = maxPageSize;
+    }
+
+    @Override
+    protected int getTreeDefaultPageSize() {
+      return maxPageSize;
+    }
+
+    @Override
+    protected int getTreeMaxPageSize() {
+      return maxPageSize;
+    }
+
+    @Override
+    protected TokenizableIterator<DirectoryEntry> createTreeIterator(
+        String reason, Digest rootDigest, String pageToken) {
+      return new TreeIterator(
+          directoryBlobDigest -> directoriesIndex.get(directoryBlobDigest), rootDigest, pageToken);
+    }
+  }
+
+  private static Directory directoryWithFiles(int fileCount, int nameSize) {
+    Directory.Builder builder = Directory.newBuilder();
+    for (int i = 0; i < fileCount; i++) {
+      builder.addFiles(
+          FileNode.newBuilder().setName(String.format("%0" + nameSize + "d", i)).build());
+    }
+    return builder.build();
+  }
+
+  /**
+   * Walks the entire tree via getTree, collecting every directory page. Returns the concatenation
+   * of all pages' directory hashes in encounter order so callers can assert no loss/duplication.
+   */
+  private static List<String> walkTree(NodeInstance instance, Digest rootDigest, int pageSize) {
+    List<String> hashes = new ArrayList<>();
+    String pageToken = "";
+    int pages = 0;
+    do {
+      build.buildfarm.v1test.Tree.Builder tree = build.buildfarm.v1test.Tree.newBuilder();
+      pageToken = instance.getTree(rootDigest, pageSize, pageToken, tree);
+      hashes.addAll(tree.getDirectoriesMap().keySet());
+      if (++pages > 1000) {
+        throw new IllegalStateException("walkTree did not terminate after 1000 pages");
+      }
+    } while (!pageToken.isEmpty());
+    return hashes;
+  }
+
+  /*-
+   * A root directory referencing many sibling child directories, each large enough that
+   * the requested pageSize worth of them exceeds the grpc message limit. getTree must
+   * return a truncated page that fits under the limit, with a continuation token, and
+   * lose no directories across the full walk.
+   */
+  @Test
+  public void getTreeTruncatesPageToMessageSizeLimit() {
+    Map<Digest, Directory> directoriesIndex = new HashMap<>();
+
+    // each child directory is ~1KiB serialized; vary content so digests are distinct (the
+    // TreeIterator page token resumes by digest, so identical siblings cannot be distinguished)
+    List<DirectoryNode> children = new ArrayList<>();
+    int childCount = 32;
+    for (int i = 0; i < childCount; i++) {
+      Directory child =
+          directoryWithFiles(/* fileCount= */ 16, /* nameSize= */ 60).toBuilder()
+              .addFiles(FileNode.newBuilder().setName(String.format("unique-%05d", i)).build())
+              .build();
+      Digest childDigest = DIGEST_UTIL.compute(child);
+      directoriesIndex.put(childDigest, child);
+      children.add(
+          DirectoryNode.newBuilder()
+              .setName(String.format("child-%05d", i))
+              .setDigest(DigestUtil.toDigest(childDigest))
+              .build());
+    }
+    // DirectoryNodes must be sorted by name for a valid Directory
+    children.sort((a, b) -> a.getName().compareTo(b.getName()));
+    Directory root = Directory.newBuilder().addAllDirectories(children).build();
+    Digest rootDigest = DIGEST_UTIL.compute(root);
+    directoriesIndex.put(rootDigest, root);
+
+    // limit chosen so several, but not all, children fit in a single page
+    int maxPageSizeBytes = 8 * 1024;
+    TreeServerInstance instance =
+        new TreeServerInstance(directoriesIndex, /* maxPageSize= */ childCount + 1);
+    instance.setGetTreeMaxMessageSizeBytes(maxPageSizeBytes);
+
+    // request the whole tree in a single page
+    int pageSize = childCount + 1;
+    build.buildfarm.v1test.Tree.Builder firstPage = build.buildfarm.v1test.Tree.newBuilder();
+    String nextPageToken = instance.getTree(rootDigest, pageSize, "", firstPage);
+
+    // the response must not have swallowed the whole tree into one oversized message;
+    // measure the actual GetTreeResponse wire message the service would send for this page
+    int firstPageBytes =
+        GetTreeResponse.newBuilder()
+            .addAllDirectories(firstPage.build().getDirectoriesMap().values())
+            .build()
+            .getSerializedSize();
+    assertThat(firstPageBytes).isAtMost(maxPageSizeBytes);
+    assertThat(nextPageToken).isNotEmpty();
+
+    // walking the whole tree must yield root + every child exactly once
+    List<String> allHashes = walkTree(instance, rootDigest, pageSize);
+    assertThat(allHashes).hasSize(childCount + 1);
+    assertThat(allHashes).containsNoDuplicates();
+    assertThat(allHashes).contains(rootDigest.getHash());
+    for (DirectoryNode child : children) {
+      assertThat(allHashes).contains(child.getDigest().getHash());
+    }
+  }
+
+  /*-
+   * The first directory of a page is always emitted, even when it alone exceeds the message
+   * size limit - otherwise getTree would make no progress and loop forever.
+   */
+  @Test
+  public void getTreeEmitsFirstDirectoryEvenWhenOversized() {
+    Map<Digest, Directory> directoriesIndex = new HashMap<>();
+    Directory root = directoryWithFiles(/* fileCount= */ 256, /* nameSize= */ 60);
+    Digest rootDigest = DIGEST_UTIL.compute(root);
+    directoriesIndex.put(rootDigest, root);
+
+    int maxPageSizeBytes = 1024; // smaller than root itself
+    assertThat(root.getSerializedSize()).isGreaterThan(maxPageSizeBytes);
+
+    TreeServerInstance instance = new TreeServerInstance(directoriesIndex, /* maxPageSize= */ 16);
+    instance.setGetTreeMaxMessageSizeBytes(maxPageSizeBytes);
+
+    build.buildfarm.v1test.Tree.Builder tree = build.buildfarm.v1test.Tree.newBuilder();
+    String nextPageToken = instance.getTree(rootDigest, /* pageSize= */ 16, "", tree);
+
+    assertThat(tree.getDirectoriesMap()).containsKey(rootDigest.getHash());
+    assertThat(nextPageToken).isEmpty();
   }
 
   @Test

--- a/src/test/java/build/buildfarm/instance/server/NodeInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/server/NodeInstanceTest.java
@@ -264,8 +264,7 @@ public class NodeInstanceTest {
     @Override
     protected TokenizableIterator<DirectoryEntry> createTreeIterator(
         String reason, Digest rootDigest, String pageToken) {
-      return new TreeIterator(
-          directoryBlobDigest -> directoriesIndex.get(directoryBlobDigest), rootDigest, pageToken);
+      return new TreeIterator(directoriesIndex::get, rootDigest, pageToken);
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #2483.

`getTree` builds a `GetTreeResponse` containing up to `pageSize` directories but only counts *how many* directories it adds, never their serialized *size*. For certain directory sizes, a page can therefore exceed the grpc per-message byte limit (4 MiB by default) and fail the RPC.

`NodeInstance.getTree` now tracks the serialized contribution of each `Directory` to the enclosing `GetTreeResponse` (message bytes + the repeated field's tag and length delimiter) and stops filling a page once the next directory would exceed a byte budget. The budget defaults to the grpc default max message size (4 MiB) less a small reserve for the response envelope (`nextPageToken`) and framing slack.

### Key properties

- **Forward progress is guaranteed.** The first directory of every page is always emitted, even if it alone exceeds the budget. A single pathological directory too large for any page still ships in its own page rather than looping on empty pages. Splitting such a directory — e.g. via a placeholder or a remote-apis message change, as the issue contemplates — is intentionally **out of scope** for this PR.
- **No loss or duplication.** The resume page token is captured *before* the iterator is advanced, so a directory deferred because it would overflow the page becomes the first entry of the next page. Walking the full tree visits every directory exactly once.

### Why a fixed 4 MiB default rather than the server config

The limit that matters for an outbound `GetTreeResponse` is the *client's* inbound message size, which the server cannot observe. The conservative grpc default (4 MiB) is the safe choice, so the budget is a settable instance field defaulting to 4 MiB rather than being read from `maxInboundMessageSizeBytes`.

## Tests

Added to `NodeInstanceTest`, backed by a `TreeServerInstance` serving an in-memory directory index through a real `TreeIterator`:

- `getTreeTruncatesPageToMessageSizeLimit` — a root referencing many ~1 KiB sibling directories requested as a single oversized page under a small byte budget. Asserts the emitted page stays under the budget, a continuation token is returned, and walking the whole tree yields every directory exactly once.
- `getTreeEmitsFirstDirectoryEvenWhenOversized` — a single directory larger than the entire budget is still emitted, so the walk makes forward progress.

Developed test-first (the first commit captures the red state; the second implements the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)