### PR TITLE
fix(worker): accept bazel's "resources:" prefix for local resources

### DIFF
--- a/_site/docs/architecture/queues.md
+++ b/_site/docs/architecture/queues.md
@@ -47,7 +47,7 @@ For each property key-value in the operation's platform, an operation is REJECTE
   Or The key is `min-mem` and the integer value is greater than the number of bytes of RAM on the worker.
   Or if the key exists in the `DequeueMatchSettings` platform with neither the value nor a `*` in the corresponding DMS platform key's values,
   Or if the `allowUnmatched` setting is `false`.
-For each resource requested in the operation's platform with the resource: prefix, the action is rejected if:
+For each resource requested in the operation's platform with the resources: prefix (or the legacy resource: prefix), the action is rejected if:
   The resource amount cannot currently be satisfied with the associated resource capacity count
 
 There are special predefined execution property names which resolve to dynamic configuration for the worker to match against:

--- a/_site/docs/configuration/configuration.md
+++ b/_site/docs/configuration/configuration.md
@@ -395,8 +395,8 @@ worker:
 
 ### Resources
 
-A list of limited resources that are available to the worker to be depleted by actions which execute containing a "resource:<name>": "N" property.
-The dequeueMatchSettings may also further limit executions to contain "resource:<name>" in properties, with either a specific limited resource count as the only accepted value for the action property. The use case here is one where executions are not allowed to request any value other than the one specified. There are no operators currently for asserting an execution requests 'less than' a particular number of resources.
+A list of limited resources that are available to the worker to be depleted by actions which execute containing a "resources:<name>": "N" property. This is the prefix bazel uses for extra resources in `tags` and `exec_properties`. The singular "resource:<name>" spelling is also accepted for backwards compatibility.
+The dequeueMatchSettings may also further limit executions to contain "resources:<name>" in properties, with either a specific limited resource count as the only accepted value for the action property. The use case here is one where executions are not allowed to request any value other than the one specified. There are no operators currently for asserting an execution requests 'less than' a particular number of resources.
 
 The default resource type is SEMAPHORE.
 The expected use case is that a resource is _internally_ allocated and managed by an execution, and the exhaustion prevents executions from starting which would block or fault if they could not consume the resource. Common examples include licensed software with tokens, and this mechanism can work for singleton resources like one gpu on a worker.
@@ -417,7 +417,7 @@ Example:
 worker:
   dequeueMatchSettings:
     properties:
-      - name: "resource:special-compiler-license"
+      - name: "resources:special-compiler-license"
         value: "1" # only actions which request one compiler license at a time will be accepted
   resources:
     name: "special-compiler-license"

--- a/src/main/java/build/buildfarm/worker/resources/LocalResourceSetUtils.java
+++ b/src/main/java/build/buildfarm/worker/resources/LocalResourceSetUtils.java
@@ -46,6 +46,18 @@ import org.jspecify.annotations.Nullable;
 public class LocalResourceSetUtils {
   private static final LocalResourceSetMetrics metrics = new LocalResourceSetMetrics();
 
+  /**
+   * The prefix bazel uses to request extra resources, both in {@code tags} and in {@code
+   * exec_properties}. See {@code ExecutionRequirements.RESOURCES} in bazel.
+   */
+  private static final String RESOURCES_PREFIX = "resources:";
+
+  /**
+   * A misspelling of {@link #RESOURCES_PREFIX} that buildfarm has accepted since local resources
+   * were introduced. Still honored so that existing configurations and actions keep working.
+   */
+  private static final String LEGACY_RESOURCE_PREFIX = "resource:";
+
   private record SemaphoreLease(String name, int amount, Claim.Stage stage)
       implements Claim.Lease {}
 
@@ -260,7 +272,7 @@ public class LocalResourceSetUtils {
 
   private static int getResourceRequestAmount(Platform.Property property) {
     // We support resource values that are not numbers and interpret them as a request for 1
-    // resource.  For example "gpu:RTX-4090" is equivalent to resource:gpu:1".
+    // resource.  For example "gpu:RTX-4090" is equivalent to resources:gpu:1".
     try {
       return Integer.parseInt(property.getValue());
     } catch (NumberFormatException e) {
@@ -269,16 +281,25 @@ public class LocalResourceSetUtils {
   }
 
   public static String getResourceName(String propertyName) {
-    // We match to keys whether they are prefixed "resource:" or not.
-    // "resource:gpu:1" requests the gpu resource in the same way that "gpu:1" does.
-    // The prefix originates from bazel's syntax for the --extra_resources flag.
-    return StringUtils.removeStart(propertyName, "resource:");
+    // We match to keys whether they are prefixed or not.
+    // "resources:gpu:1" requests the gpu resource in the same way that "gpu:1" does.
+    // The prefix originates from bazel's syntax for extra resources, which spells it "resources:".
+    // The singular "resource:" is a buildfarm misspelling that is still accepted.
+    if (propertyName.startsWith(RESOURCES_PREFIX)) {
+      return propertyName.substring(RESOURCES_PREFIX.length());
+    }
+    return StringUtils.removeStart(propertyName, LEGACY_RESOURCE_PREFIX);
   }
 
   public static boolean satisfies(LocalResourceSet resourceSet, Platform.Property property) {
     String name = property.getName();
-    return name.startsWith("resource:")
+    return hasResourcePrefix(name)
         && (resourceSet.resources.containsKey(getResourceName(name))
             || resourceSet.poolResources.containsKey(getResourceName(name)));
+  }
+
+  private static boolean hasResourcePrefix(String propertyName) {
+    return propertyName.startsWith(RESOURCES_PREFIX)
+        || propertyName.startsWith(LEGACY_RESOURCE_PREFIX);
   }
 }

--- a/src/test/java/build/buildfarm/worker/DequeueMatchEvaluatorTest.java
+++ b/src/test/java/build/buildfarm/worker/DequeueMatchEvaluatorTest.java
@@ -368,6 +368,69 @@ public class DequeueMatchEvaluatorTest {
     assertThat(resourceSet.resources.get("BAZ").availablePermits()).isEqualTo(200);
   }
 
+  // Function under test: acquireClaim
+  // Reason for testing: bazel spells the resource prefix "resources:", and such a request should
+  // claim the same resource as the legacy "resource:" spelling.
+  // Failure explanation: the bazel-compatible prefix is not recognized as a resource request.
+  @Test
+  public void shouldKeepOperationClaimsResourceWithPluralPrefix() throws Exception {
+    // ARRANGE
+    // unmatched properties are rejected, so the property is only kept if it is understood to be a
+    // resource request.
+    configs.getWorker().getDequeueMatchSettings().setAllowUnmatched(false);
+    SetMultimap<String, String> workerProvisions = HashMultimap.create();
+    LocalResourceSet resourceSet = new LocalResourceSet();
+    resourceSet.resources.put("FOO", new SemaphoreResource(new Semaphore(1), EXECUTE_ACTION_STAGE));
+
+    Platform platform =
+        Platform.newBuilder()
+            .addProperties(Platform.Property.newBuilder().setName("resources:FOO").setValue("1"))
+            .build();
+
+    // PRE-ASSERT
+    assertThat(resourceSet.resources.get("FOO").availablePermits()).isEqualTo(1);
+
+    // ACT
+    Claim claim = acquireClaim(workerProvisions, resourceSet, platform);
+
+    // ASSERT
+    // the worker accepts because the resource is available.
+    assertThat(claim).isNotNull();
+    assertThat(resourceSet.resources.get("FOO").availablePermits()).isEqualTo(0);
+
+    // ACT
+    claim = acquireClaim(workerProvisions, resourceSet, platform);
+
+    // ASSERT
+    // the worker rejects because there are no resources left.
+    assertThat(claim).isNull();
+    assertThat(resourceSet.resources.get("FOO").availablePermits()).isEqualTo(0);
+  }
+
+  // Function under test: acquireClaim
+  // Reason for testing: the legacy "resource:" spelling must keep working alongside "resources:".
+  // Failure explanation: the legacy prefix is no longer recognized as a resource request.
+  @Test
+  public void shouldKeepOperationClaimsResourceWithLegacyPrefix() throws Exception {
+    // ARRANGE
+    configs.getWorker().getDequeueMatchSettings().setAllowUnmatched(false);
+    SetMultimap<String, String> workerProvisions = HashMultimap.create();
+    LocalResourceSet resourceSet = new LocalResourceSet();
+    resourceSet.resources.put("FOO", new SemaphoreResource(new Semaphore(1), EXECUTE_ACTION_STAGE));
+
+    Platform platform =
+        Platform.newBuilder()
+            .addProperties(Platform.Property.newBuilder().setName("resource:FOO").setValue("1"))
+            .build();
+
+    // ACT
+    Claim claim = acquireClaim(workerProvisions, resourceSet, platform);
+
+    // ASSERT
+    assertThat(claim).isNotNull();
+    assertThat(resourceSet.resources.get("FOO").availablePermits()).isEqualTo(0);
+  }
+
   @Test
   public void shouldMatchCoresAsMinAndMax() throws Exception {
     SetMultimap<String, String> workerProvisions = HashMultimap.create();

--- a/src/test/java/build/buildfarm/worker/resources/LocalResourceSetUtilsTest.java
+++ b/src/test/java/build/buildfarm/worker/resources/LocalResourceSetUtilsTest.java
@@ -56,4 +56,44 @@ public class LocalResourceSetUtilsTest {
     claim.release();
     assertThat(foo.availablePermits()).isEqualTo(1);
   }
+
+  // Function under test: getResourceName
+  // Reason for testing: bazel spells the prefix "resources:", but the singular "resource:" has
+  // always been accepted by buildfarm and must keep working.
+  // Failure explanation: a resource request is not resolved to the configured resource name.
+  @Test
+  public void getResourceNameStripsEitherPrefix() throws Exception {
+    assertThat(LocalResourceSetUtils.getResourceName("resources:FOO")).isEqualTo("FOO");
+    assertThat(LocalResourceSetUtils.getResourceName("resource:FOO")).isEqualTo("FOO");
+    // unprefixed names are used as-is
+    assertThat(LocalResourceSetUtils.getResourceName("FOO")).isEqualTo("FOO");
+    // only the leading prefix is stripped
+    assertThat(LocalResourceSetUtils.getResourceName("resources:resources:FOO"))
+        .isEqualTo("resources:FOO");
+  }
+
+  // Function under test: claimResources
+  // Reason for testing: a "resources:" request should claim the same resource as "resource:".
+  // Failure explanation: the bazel-compatible prefix does not claim the configured resource.
+  @Test
+  public void claimsResourceWithPluralPrefix() throws Exception {
+    // ARRANGE
+    LocalResourceSet resourceSet = new LocalResourceSet();
+    Semaphore foo = new Semaphore(1);
+    resourceSet.resources.put("FOO", new SemaphoreResource(foo, EXECUTE_ACTION_STAGE));
+
+    Platform platform =
+        Platform.newBuilder()
+            .addProperties(Platform.Property.newBuilder().setName("resources:FOO").setValue("1"))
+            .build();
+
+    // ACT
+    Claim claim = LocalResourceSetUtils.claimResources(platform, resourceSet);
+
+    // ASSERT
+    assertThat(claim).isNotNull();
+    assertThat(foo.availablePermits()).isEqualTo(0);
+    claim.release();
+    assertThat(foo.availablePermits()).isEqualTo(1);
+  }
 }


### PR DESCRIPTION
Bazel spells extra resource requests as `resources:<name>`, both in `tags` and in `exec_properties` (see [`ExecutionRequirements.RESOURCES`](https://github.com/bazelbuild/bazel/blob/d62b2b8bc05f8ee4d82262d3eddff179490c857a/src/main/java/com/google/devtools/build/lib/actions/ExecutionRequirements.java#L165)).

Buildfarm only matches the singular `resource:<name>`, even though the comment on `getResourceName` says the prefix "originates from bazel's syntax". An action written using Bazel's documented syntax therefore never actually claimed a local resource.

This change makes it so that both spellings are accepted, leaving existing configurations and actions are unaffected.
