### PR TITLE
Make AtomicFileWriter more

### DIFF
--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -70,6 +70,7 @@ import build.buildfarm.common.io.CountingOutputStream;
 import build.buildfarm.common.io.Directories;
 import build.buildfarm.common.io.FeedbackOutputStream;
 import build.buildfarm.common.io.FileStatus;
+import build.buildfarm.common.io.FileSystemMover;
 import build.buildfarm.v1test.BlobWriteKey;
 import build.buildfarm.v1test.Digest;
 import com.google.common.annotations.VisibleForTesting;
@@ -174,7 +175,8 @@ public abstract class CASFileCache implements ContentAddressableStorage {
   private final Consumer<Iterable<Digest>> onExpire;
   private final Executor accessRecorder;
   private final ExecutorService expireService;
-  private final LRUDB db = new TextLRUDB();
+  private LRUDB db;
+  private FileSystemMover fileSystemMover;
   private volatile Deadline saveLRUAfter = Deadline.after(10, MINUTES);
   private final Path lru;
 
@@ -1296,6 +1298,10 @@ public abstract class CASFileCache implements ContentAddressableStorage {
       Files.createDirectories(dir);
     }
     fileStore = Files.getFileStore(root);
+    if (fileSystemMover == null) {
+      fileSystemMover = FileSystemMover.probe(root);
+      db = new TextLRUDB(fileSystemMover);
+    }
   }
 
   @SuppressWarnings({"PMD.CompareObjectsWithEquals"})
@@ -2640,13 +2646,13 @@ public abstract class CASFileCache implements ContentAddressableStorage {
         boolean inserted = false;
         try {
           // acquire the key lock
-          Files.createLink(CASFileCache.this.getPath(actual, key), writePath);
+          fileSystemMover.move(writePath, CASFileCache.this.getPath(actual, key));
           existingEntry = safeStorageInsertion(key, entry);
           inserted = existingEntry == null;
         } catch (FileAlreadyExistsException e) {
           log.log(Level.FINER, "file already exists for " + key + ", nonexistent entry will fail");
         } finally {
-          Files.delete(writePath);
+          Files.deleteIfExists(writePath);
           if (!inserted) {
             dischargeAndNotify(writeKey, blobSizeInBytes);
           }

--- a/src/main/java/build/buildfarm/cas/cfc/TextLRUDB.java
+++ b/src/main/java/build/buildfarm/cas/cfc/TextLRUDB.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static java.lang.String.format;
 
 import build.buildfarm.common.io.AtomicFileWriter;
+import build.buildfarm.common.io.FileSystemMover;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -11,6 +12,12 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 class TextLRUDB implements LRUDB {
+  private final FileSystemMover fileSystemMover;
+
+  TextLRUDB(FileSystemMover fileSystemMover) {
+    this.fileSystemMover = fileSystemMover;
+  }
+
   private static class EntriesIterator implements Iterator<SizeEntry> {
     private String next = null;
     private final BufferedReader br;
@@ -60,7 +67,7 @@ class TextLRUDB implements LRUDB {
 
   @Override
   public void save(Iterator<SizeEntry> entries, Path path) throws IOException {
-    try (AtomicFileWriter writer = new AtomicFileWriter(path)) {
+    try (AtomicFileWriter writer = new AtomicFileWriter(path, fileSystemMover)) {
       while (entries.hasNext()) {
         SizeEntry entry = entries.next();
         writer.write(format("%s,%d\n", entry.key(), entry.size()));

--- a/src/main/java/build/buildfarm/common/io/AtomicFileWriter.java
+++ b/src/main/java/build/buildfarm/common/io/AtomicFileWriter.java
@@ -19,7 +19,6 @@ import static com.google.common.base.Preconditions.checkState;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.UUID;
 
@@ -27,13 +26,15 @@ import java.util.UUID;
  * A writer that atomically presents a target file only on successful close.
  *
  * <p>Writes are performed to a temporary file with a unique UUID suffix. On successful close(), the
- * target file is atomically replaced via hard link, and the temporary file is deleted.
+ * temp file is installed at the target using a {@link FileSystemMover} whose strategy is determined
+ * once at startup.
  *
  * <p>Usage:
  *
  * <pre>{@code
- * try (AtomicFileWriter atomicWriter = new AtomicFileWriter(target)) {
- *   writer.write("data");
+ * try (AtomicFileWriter atomicWriter = new AtomicFileWriter(target, fileSystemMover)) {
+ *   atomicWriter.write("data");
+ *   atomicWriter.onSuccess();
  * } // Automatic atomic swap and cleanup on close
  * }</pre>
  *
@@ -48,6 +49,7 @@ import java.util.UUID;
 public class AtomicFileWriter extends BufferedWriter {
   private final Path target;
   private final Path temp;
+  private final FileSystemMover fileSystemMover;
   private boolean closed = false;
   private boolean success = false;
 
@@ -61,17 +63,20 @@ public class AtomicFileWriter extends BufferedWriter {
    * Creates an AtomicFileWriter for the specified target path.
    *
    * @param target the final destination path for the file
+   * @param fileSystemMover the replacement strategy selected for the target filesystem
    * @throws IOException if the temporary file cannot be created
    */
-  public AtomicFileWriter(Path target) throws IOException {
-    this(target, createSiblingRandomUUIDTemp(target));
+  public AtomicFileWriter(Path target, FileSystemMover fileSystemMover) throws IOException {
+    this(target, createSiblingRandomUUIDTemp(target), fileSystemMover);
   }
 
-  private AtomicFileWriter(Path target, Path temp) throws IOException {
+  private AtomicFileWriter(Path target, Path temp, FileSystemMover fileSystemMover)
+      throws IOException {
     super(Files.newBufferedWriter(temp));
     checkState(!target.equals(temp));
     this.target = target;
     this.temp = temp;
+    this.fileSystemMover = fileSystemMover;
   }
 
   public void onSuccess() {
@@ -79,20 +84,12 @@ public class AtomicFileWriter extends BufferedWriter {
   }
 
   /**
-   * Closes the writer and atomically replaces the target file.
+   * Closes the writer and replaces the target using the selected filesystem strategy.
    *
-   * <p>This method:
+   * <p>On success, the configured filesystem mover installs the temp file at the target. On failure
+   * (close threw, onSuccess was never called, or the move threw), the temp file is removed.
    *
-   * <ol>
-   *   <li>Closes the BufferedWriter
-   *   <li>Deletes the target file if it exists
-   *   <li>Creates a hard link from temp file to target (atomic replacement)
-   *   <li>Deletes the temporary file
-   * </ol>
-   *
-   * The temporary file is always deleted, even if an error occurs during the atomic swap.
-   *
-   * @throws IOException if an error occurs during the atomic swap
+   * @throws IOException if an error occurs during replacement
    */
   @Override
   public void close() throws IOException {
@@ -109,19 +106,13 @@ public class AtomicFileWriter extends BufferedWriter {
         replace();
       }
     } finally {
-      Files.delete(temp);
+      // After a successful atomic move the temp no longer exists; deleteIfExists handles both
+      // that case and the failure paths where the temp survived.
+      Files.deleteIfExists(temp);
     }
   }
 
   private void replace() throws IOException {
-    // Delete target file (ignore if doesn't exist)
-    try {
-      Files.delete(target);
-    } catch (NoSuchFileException e) {
-      // Ignore - file may not exist
-    }
-
-    // Create hard link to atomically replace
-    Files.createLink(target, temp);
+    fileSystemMover.move(temp, target);
   }
 }

--- a/src/main/java/build/buildfarm/common/io/FileSystemMover.java
+++ b/src/main/java/build/buildfarm/common/io/FileSystemMover.java
@@ -1,0 +1,86 @@
+// Copyright 2026 The Buildfarm Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common.io;
+
+import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+
+import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/** Moves temporary files into their final location using a strategy fixed at startup. */
+public final class FileSystemMover {
+  private static final Logger log = Logger.getLogger(FileSystemMover.class.getName());
+
+  @FunctionalInterface
+  private interface Move {
+    void apply(Path source, Path target) throws IOException;
+  }
+
+  private final Move move;
+
+  private FileSystemMover(Move move) {
+    this.move = move;
+  }
+
+  /**
+   * Determines once whether the filesystem containing {@code directory} supports atomic moves.
+   *
+   * <p>The returned mover always uses the selected strategy. Filesystems without atomic-move
+   * support use the legacy delete-and-hard-link sequence.
+   */
+  public static FileSystemMover probe(Path directory) throws IOException {
+    Path source = Files.createTempFile(directory, ".atomic-move-probe-", ".tmp");
+    Path target = Files.createTempFile(directory, ".atomic-move-probe-target-", ".tmp");
+    try {
+      Files.move(source, target, ATOMIC_MOVE, REPLACE_EXISTING);
+      log.log(Level.INFO, "using atomic moves for " + directory);
+      return atomicMover();
+    } catch (AtomicMoveNotSupportedException e) {
+      log.log(
+          Level.WARNING,
+          "atomic move not supported for "
+              + directory
+              + "; using non-atomic delete and hard-link replacement",
+          e);
+      return hardLinkMover();
+    } finally {
+      Files.deleteIfExists(source);
+      Files.deleteIfExists(target);
+    }
+  }
+
+  /** Replaces {@code target} with {@code source}. The source may remain for hard-link moves. */
+  public void move(Path source, Path target) throws IOException {
+    move.apply(source, target);
+  }
+
+  static FileSystemMover atomicMover() {
+    return new FileSystemMover(
+        (source, target) -> Files.move(source, target, ATOMIC_MOVE, REPLACE_EXISTING));
+  }
+
+  static FileSystemMover hardLinkMover() {
+    return new FileSystemMover(
+        (source, target) -> {
+          Files.deleteIfExists(target);
+          Files.createLink(target, source);
+        });
+  }
+}

--- a/src/test/java/build/buildfarm/cas/cfc/TextLRUDBTest.java
+++ b/src/test/java/build/buildfarm/cas/cfc/TextLRUDBTest.java
@@ -18,6 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import build.buildfarm.cas.cfc.LRUDB.SizeEntry;
+import build.buildfarm.common.io.FileSystemMover;
 import com.google.common.collect.Iterables;
 import com.google.common.jimfs.Jimfs;
 import java.io.BufferedReader;
@@ -43,10 +44,10 @@ public class TextLRUDBTest {
   private Path rootDir;
 
   @Before
-  public void setUp() {
-    textLRUDB = new TextLRUDB();
+  public void setUp() throws IOException {
     fileSystem = Jimfs.newFileSystem();
     rootDir = Iterables.getFirst(fileSystem.getRootDirectories(), null);
+    textLRUDB = new TextLRUDB(FileSystemMover.probe(rootDir));
   }
 
   @After

--- a/src/test/java/build/buildfarm/common/io/AtomicFileWriterTest.java
+++ b/src/test/java/build/buildfarm/common/io/AtomicFileWriterTest.java
@@ -30,11 +30,13 @@ import org.junit.runners.JUnit4;
 public class AtomicFileWriterTest {
   private Path root;
   private FileStore fileStore;
+  private FileSystemMover fileSystemMover;
 
   @Before
   public void setUp() throws IOException {
     root = Files.createTempDirectory("atomic-file-writer-test");
     fileStore = Files.getFileStore(root);
+    fileSystemMover = FileSystemMover.probe(root);
   }
 
   @After
@@ -46,7 +48,7 @@ public class AtomicFileWriterTest {
   public void successCreatesTarget() throws IOException {
     Path target = root.resolve("test.txt");
 
-    try (AtomicFileWriter writer = new AtomicFileWriter(target)) {
+    try (AtomicFileWriter writer = new AtomicFileWriter(target, fileSystemMover)) {
       writer.write("test content");
       writer.onSuccess();
     }
@@ -63,7 +65,7 @@ public class AtomicFileWriterTest {
     Path target = root.resolve("test.txt");
     Files.writeString(target, "old content");
 
-    try (AtomicFileWriter writer = new AtomicFileWriter(target)) {
+    try (AtomicFileWriter writer = new AtomicFileWriter(target, fileSystemMover)) {
       writer.write("new content");
       writer.onSuccess();
     }
@@ -72,10 +74,23 @@ public class AtomicFileWriterTest {
   }
 
   @Test
+  public void hardLinkMoverSuccessCleansUpTempFile() throws IOException {
+    Path target = root.resolve("test.txt");
+
+    try (AtomicFileWriter writer = new AtomicFileWriter(target, FileSystemMover.hardLinkMover())) {
+      writer.write("test content");
+      writer.onSuccess();
+    }
+
+    assertThat(Files.readString(target)).isEqualTo("test content");
+    assertThat(Files.list(root)).containsExactly(target);
+  }
+
+  @Test
   public void atomicFileWriterCleansUpOnException() throws IOException {
     Path target = root.resolve("test.txt");
 
-    try (AtomicFileWriter writer = new AtomicFileWriter(target)) {
+    try (AtomicFileWriter writer = new AtomicFileWriter(target, fileSystemMover)) {
       writer.write("partial");
       throw new IOException("simulated error");
     } catch (IOException e) {
@@ -94,7 +109,7 @@ public class AtomicFileWriterTest {
   public void closeWithoutSuccessPreventsReplace() throws IOException {
     Path target = root.resolve("test.txt");
 
-    try (AtomicFileWriter writer = new AtomicFileWriter(target)) {
+    try (AtomicFileWriter writer = new AtomicFileWriter(target, fileSystemMover)) {
       writer.write("partial");
     }
 
@@ -111,7 +126,7 @@ public class AtomicFileWriterTest {
 
     Files.writeString(target, "complete");
 
-    try (AtomicFileWriter writer = new AtomicFileWriter(target)) {
+    try (AtomicFileWriter writer = new AtomicFileWriter(target, fileSystemMover)) {
       writer.write("partial");
     }
 
@@ -127,8 +142,8 @@ public class AtomicFileWriterTest {
     Path target = root.resolve("test.txt");
 
     // Create two writers to same target - should have different temp files
-    AtomicFileWriter writer1 = new AtomicFileWriter(target);
-    AtomicFileWriter writer2 = new AtomicFileWriter(target);
+    AtomicFileWriter writer1 = new AtomicFileWriter(target, fileSystemMover);
+    AtomicFileWriter writer2 = new AtomicFileWriter(target, fileSystemMover);
 
     // Both should succeed without collision
     writer1.write("content1");
@@ -151,7 +166,7 @@ public class AtomicFileWriterTest {
   public void writeAppends() throws IOException {
     Path target = root.resolve("multiline.txt");
 
-    try (AtomicFileWriter writer = new AtomicFileWriter(target)) {
+    try (AtomicFileWriter writer = new AtomicFileWriter(target, fileSystemMover)) {
       writer.write("line1\n");
       writer.write("line2\n");
       writer.write("line3\n");
@@ -166,7 +181,7 @@ public class AtomicFileWriterTest {
   public void closeIsIdempotent() throws IOException {
     Path target = root.resolve("test.txt");
 
-    AtomicFileWriter writer = new AtomicFileWriter(target);
+    AtomicFileWriter writer = new AtomicFileWriter(target, fileSystemMover);
     writer.write("test content");
     writer.onSuccess();
     writer.close();

--- a/src/test/java/build/buildfarm/common/io/FileSystemMoverTest.java
+++ b/src/test/java/build/buildfarm/common/io/FileSystemMoverTest.java
@@ -1,0 +1,59 @@
+// Copyright 2026 The Buildfarm Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common.io;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class FileSystemMoverTest {
+  @Test
+  public void atomicMoverReplacesTargetAndConsumesSource() throws IOException {
+    Path root = Files.createTempDirectory("atomic-mover-test");
+    try {
+      Path source = Files.writeString(root.resolve("source"), "new");
+      Path target = Files.writeString(root.resolve("target"), "old");
+
+      FileSystemMover.atomicMover().move(source, target);
+
+      assertThat(Files.readString(target)).isEqualTo("new");
+      assertThat(Files.exists(source)).isFalse();
+    } finally {
+      Directories.remove(root, Files.getFileStore(root));
+    }
+  }
+
+  @Test
+  public void hardLinkMoverReplacesTargetAndPreservesSource() throws IOException {
+    Path root = Files.createTempDirectory("hard-link-mover-test");
+    try {
+      Path source = Files.writeString(root.resolve("source"), "new");
+      Path target = Files.writeString(root.resolve("target"), "old");
+
+      FileSystemMover.hardLinkMover().move(source, target);
+
+      assertThat(Files.readString(target)).isEqualTo("new");
+      assertThat(Files.isSameFile(source, target)).isTrue();
+    } finally {
+      Directories.remove(root, Files.getFileStore(root));
+    }
+  }
+}


### PR DESCRIPTION
The "atomic" swap on success was Files.delete(target) followed by Files.createLink(target, temp) — two syscalls with a window where a JVM crash, host crash, or fault between them leaves the target gone and only the temp .uuid file behind. Subsequent startup paths that expected the target to exist (CASFileCache's lru.txt) would see a missing file and fall back to a full filesystem scan; on a 54TB CAS worker that's an extra long minute of cold cache misses on every unclean restart.

Switch replace() to Files.move(temp, target, ATOMIC_MOVE, REPLACE_EXISTING) — a single renameat2 on POSIX filesystems with the atomicity the class name has claimed all along. Filesystems that don't support atomic rename (rare; some Windows cross-volume cases) fall back to the legacy delete + createLink with a WARNING log so operators see the reduced durability rather than discovering it after a crash. The outer finally switches Files.delete(temp) to deleteIfExists since after a successful move the temp file no longer exists; on the failure paths the temp still does and gets cleaned up as before.