### PR TITLE
Add maxSizePercent config for CAS filesystem storage

### DIFF
--- a/_site/docs/configuration/configuration.md
+++ b/_site/docs/configuration/configuration.md
@@ -432,7 +432,8 @@ Unless specified, options are only relevant for FILESYSTEM type
 |------------------------------|-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
 | type                         | _FILESYSTEM_, GRPC            | Type of CAS used                                                                                                                                   |
 | path                         | String, _cache_               | Local cache location relative to the 'root', or absolute                                                                                           |
-| maxSizeBytes                 | Integer, _0_                  | Limit for contents of files retained from CAS in the cache, value of 0 means to auto-configure to 90% of _root_/_path_ underlying filesystem space |
+| maxSizeBytes                 | Integer, _0_                  | Limit in bytes for contents of files retained from CAS in the cache. Mutually exclusive with maxSizePercent. A value of 0 means to use maxSizePercent instead. |
+| maxSizePercent               | Integer (0-100), _0_          | Limit in percent of the _root_/_path_ underlying filesystem space for contents of files retained from CAS in the cache. Mutually exclusive with maxSizeBytes. 0 means not set. If both maxSizePercent and maxSizeBytes are 0, then maxSizePercent is used at 90%. |
 | fileDirectoriesIndexInMemory | boolean, _false_              | Determines if the file directories bidirectional mapping should be stored in memory or in sqlite                                                  |
 | skipLoad                     | boolean, _false_              | Determines if transient data on the worker should be loaded into CAS on worker startup (affects startup time)                                |
 | target                       | String, _null_                | For GRPC CAS type, target for external CAS endpoint                                                                                                |
@@ -447,6 +448,16 @@ worker:
     - type: FILESYSTEM
       path: "cache"
       maxSizeBytes: 2147483648 # 2 * 1024 * 1024 * 1024
+```
+
+This definition will create a filesystem-based CAS file cache that uses 75% of the filesystem for CAS storage.
+
+```yaml
+worker:
+  storages:
+    - type: FILESYSTEM
+      path: "cache"
+      maxSizePercent: 75
 ```
 
 This definition elides FILESYSTEM configuration with '...', will read-through an external GRPC CAS supporting the REAPI CAS Services into its storage, and will attempt to write expiring entries into the GRPC CAS (i.e. pushing new entries into the head of a worker LRU list will drop the entries from the tail into the GRPC CAS).

--- a/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
+++ b/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
@@ -4,6 +4,7 @@ import build.buildfarm.common.DigestUtil;
 import build.buildfarm.common.ExecutionProperties;
 import build.buildfarm.common.ExecutionWrapperProperties;
 import build.buildfarm.common.SystemProcessors;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.devtools.common.options.OptionsParser;
 import com.google.devtools.common.options.OptionsParsingException;
@@ -36,6 +37,8 @@ public final class BuildfarmConfigs {
   private static Constructor constructor;
 
   private static final long DEFAULT_CAS_SIZE = 2147483648L; // 2 * 1024 * 1024 * 1024
+
+  @VisibleForTesting static final int DEFAULT_MAX_SIZE_PERCENT = 90;
 
   private static final class ImportConstruct extends AbstractConstruct {
     String configsBasePath;
@@ -207,7 +210,7 @@ public final class BuildfarmConfigs {
     adjustRedisUri(configs);
   }
 
-  private static void adjustWorkerConfigs(BuildfarmConfigs configs) {
+  private static void adjustWorkerConfigs(BuildfarmConfigs configs) throws ConfigurationException {
     configs
         .getWorker()
         .setPublicName(
@@ -215,8 +218,8 @@ public final class BuildfarmConfigs {
     adjustRedisUri(configs);
     adjustCompressedBlobTransfer(configs);
 
-    // Automatically set disk space to 90% of available space on the worker volume.
-    // User configured value in .yaml will always take presedence.
+    // Automatically set disk space to maxSizePercent of the worker volume.
+    // User configured value in .yaml will always take precedence.
     for (Cas storage : configs.getWorker().getStorages()) {
       deriveCasStorage(storage);
     }
@@ -310,14 +313,38 @@ public final class BuildfarmConfigs {
     }
   }
 
-  private static void deriveCasStorage(Cas storage) {
+  @VisibleForTesting
+  static void validateCasStorageSizeConfig(Cas storage) throws ConfigurationException {
+    long maxSizeBytes = storage.getMaxSizeBytes();
+    int maxSizePercent = storage.getMaxSizePercent();
+    if (maxSizeBytes < 0) {
+      throw new ConfigurationException("maxSizeBytes must be non-negative, got: " + maxSizeBytes);
+    }
+    if (maxSizeBytes != 0 && maxSizePercent != 0) {
+      throw new ConfigurationException(
+          "maxSizeBytes and maxSizePercent cannot both be non-zero; please use one or the other");
+    }
+    if (maxSizePercent < 0 || maxSizePercent > 100) {
+      throw new ConfigurationException(
+          "maxSizePercent must be between 0 and 100, got: " + maxSizePercent);
+    }
+  }
+
+  @VisibleForTesting
+  static void deriveCasStorage(Cas storage) throws ConfigurationException {
+    validateCasStorageSizeConfig(storage);
     if (storage.getMaxSizeBytes() == 0) {
+      int maxSizePercent = storage.getMaxSizePercent();
+      if (maxSizePercent <= 0) {
+        maxSizePercent = DEFAULT_MAX_SIZE_PERCENT;
+      }
       try {
         storage.setMaxSizeBytes(
             (long)
                 (BuildfarmConfigs.getInstance().getWorker().getValidRoot().toFile().getTotalSpace()
-                    * 0.9));
+                    * (maxSizePercent / 100.0)));
       } catch (Exception e) {
+        log.warning("Failed to determine filesystem size, falling back to default CAS size: " + e);
         storage.setMaxSizeBytes(DEFAULT_CAS_SIZE);
       }
       log.info(String.format("CAS size changed to %d", storage.getMaxSizeBytes()));

--- a/src/main/java/build/buildfarm/common/config/Cas.java
+++ b/src/main/java/build/buildfarm/common/config/Cas.java
@@ -20,6 +20,7 @@ public class Cas {
   private String path = "cache";
   private int hexBucketLevels = 0;
   private long maxSizeBytes = 0;
+  private int maxSizePercent = 0;
   private boolean fileDirectoriesIndexInMemory = false;
   private boolean skipLoad = false;
 

--- a/src/test/java/build/buildfarm/common/config/BuildfarmConfigsTest.java
+++ b/src/test/java/build/buildfarm/common/config/BuildfarmConfigsTest.java
@@ -1,5 +1,6 @@
 package build.buildfarm.common.config;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
@@ -7,6 +8,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import javax.naming.ConfigurationException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -73,5 +75,95 @@ public class BuildfarmConfigsTest {
     assertNotNull(configs);
     assertNotNull(configs.getServer());
     assertNotNull(configs.getBackplane());
+  }
+
+  @Test
+  public void validateCasStorageSizeConfig_bothSet_throws() {
+    Cas cas = new Cas();
+    cas.setMaxSizeBytes(1000);
+    cas.setMaxSizePercent(50);
+    // Both maxSizeBytes and maxSizePercent can't be non-zero simultaneously
+    assertThrows(
+        ConfigurationException.class, () -> BuildfarmConfigs.validateCasStorageSizeConfig(cas));
+  }
+
+  @Test
+  public void validateCasStorageSizeConfig_bytesNegative_throws() {
+    Cas cas = new Cas();
+    cas.setMaxSizeBytes(-1);
+    // maxSizeBytes must be non-negative
+    assertThrows(
+        ConfigurationException.class, () -> BuildfarmConfigs.validateCasStorageSizeConfig(cas));
+  }
+
+  @Test
+  public void validateCasStorageSizeConfig_percentNegative_throws() {
+    Cas cas = new Cas();
+    cas.setMaxSizePercent(-1);
+    // maxSizePercent must be positive
+    assertThrows(
+        ConfigurationException.class, () -> BuildfarmConfigs.validateCasStorageSizeConfig(cas));
+  }
+
+  @Test
+  public void validateCasStorageSizeConfig_percentOver100_throws() {
+    Cas cas = new Cas();
+    cas.setMaxSizePercent(101);
+    // maxSizePercent must be 100 or smaller
+    assertThrows(
+        ConfigurationException.class, () -> BuildfarmConfigs.validateCasStorageSizeConfig(cas));
+  }
+
+  private void setCasMaxSizePercentAndValidateSize(int maxSizePercent)
+      throws ConfigurationException {
+    Worker worker = new Worker();
+    worker.setRoot(tempDir.toString());
+    BuildfarmConfigs.getInstance().setWorker(worker);
+
+    Cas cas = new Cas();
+    cas.setMaxSizePercent(maxSizePercent);
+    cas.setMaxSizeBytes(0);
+    // When both maxSizePercent and maxSizeBytes are 0, maxSizePercent is preferred and set to
+    // DEFAULT_MAX_SIZE_PERCENT
+    if (maxSizePercent == 0) {
+      maxSizePercent = BuildfarmConfigs.DEFAULT_MAX_SIZE_PERCENT;
+    }
+    BuildfarmConfigs.deriveCasStorage(cas);
+    long expectedBytes = (long) (tempDir.toFile().getTotalSpace() * maxSizePercent / 100.0);
+    assertEquals(expectedBytes, cas.getMaxSizeBytes());
+  }
+
+  @Test
+  public void deriveCasStorage_validMaxSizePercent_computesCorrectBytes()
+      throws ConfigurationException {
+    // When valid maxSizePercent values are used, the CAS size is limited correctly
+    setCasMaxSizePercentAndValidateSize(100);
+    setCasMaxSizePercentAndValidateSize(1);
+  }
+
+  @Test
+  public void deriveCasStorage_maxSizePercentAndMaxSizeBytesAt0_defaultsToDefaultMaxSizePercent()
+      throws ConfigurationException {
+    setCasMaxSizePercentAndValidateSize(0);
+  }
+
+  @Test
+  public void deriveCasStorage_maxSizeBytesAlone_limitSetCorrectly() throws ConfigurationException {
+    Cas cas = new Cas();
+    cas.setMaxSizeBytes(1000);
+    cas.setMaxSizePercent(0);
+    BuildfarmConfigs.deriveCasStorage(cas);
+    // When maxSizePercent is 0, maxSizeBytes is used and set correctly
+    assertEquals(1000, cas.getMaxSizeBytes());
+  }
+
+  @Test
+  public void loadConfigs_withMaxSizePercent_parsesCorrectly() throws IOException {
+    Path configFile = tempDir.resolve("percent.yaml");
+    String yamlContent = "worker:\n  storages:\n    - maxSizePercent: 75\n";
+    Files.write(configFile, yamlContent.getBytes());
+
+    BuildfarmConfigs configs = BuildfarmConfigs.loadConfigs(configFile);
+    assertEquals(75, configs.getWorker().getStorages().get(0).getMaxSizePercent());
   }
 }


### PR DESCRIPTION
Currently when maxSizeBytes is 0, the CAS size limit is auto configured to 90% of the filesystem. We found that value to be too aggressive for our exec workers and were running out of disk space.

This change adds a configurable maxSizePercent option that is mutually exclusive with maxSizeBytes. When maxSizePercent is set, it is used to limit the percent of the filesystem used for the CAS.

If neither maxSizeBytes nor maxSizePercent is set, then the maxSizePercent is used and set to 90%, which preserves the prior default behavior.