### PR TITLE
Fix native memory leak in StubWriteOutputStream

### DIFF
--- a/src/main/java/build/buildfarm/common/grpc/StubWriteOutputStream.java
+++ b/src/main/java/build/buildfarm/common/grpc/StubWriteOutputStream.java
@@ -16,6 +16,7 @@ package build.buildfarm.common.grpc;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static java.lang.String.format;
 import static java.util.logging.Level.WARNING;
@@ -28,6 +29,7 @@ import com.google.bytestream.ByteStreamProto.QueryWriteStatusRequest;
 import com.google.bytestream.ByteStreamProto.QueryWriteStatusResponse;
 import com.google.bytestream.ByteStreamProto.WriteRequest;
 import com.google.bytestream.ByteStreamProto.WriteResponse;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.base.Throwables;
@@ -111,6 +113,22 @@ public class StubWriteOutputStream extends FeedbackOutputStream implements Write
   @GuardedBy("this")
   private StreamObserver<WriteRequest> writeObserver = null;
 
+  @GuardedBy("this")
+  private boolean isGrpcRemoteCallClosed = false;
+
+  @GuardedBy("this")
+  private boolean isFullyClosed = false;
+
+  @VisibleForTesting
+  synchronized boolean isGrpcRemoteCallClosed() {
+    return isGrpcRemoteCallClosed;
+  }
+
+  @VisibleForTesting
+  synchronized boolean isFullyClosed() {
+    return isFullyClosed;
+  }
+
   private long deadlineAfter = 0;
   private TimeUnit deadlineAfterUnits = null;
   private Runnable onReadyHandler = null;
@@ -141,26 +159,46 @@ public class StubWriteOutputStream extends FeedbackOutputStream implements Write
 
   @Override
   public void close() throws IOException {
+    if (isFullyClosed()) {
+      return;
+    }
     StreamObserver<WriteRequest> finishedWriteObserver;
     boolean cancelled = false;
-    if (!checkComplete()) {
-      boolean finishWrite =
-          expectedSize == COMPRESSED_EXPECTED_SIZE || expectedSize == UNLIMITED_EXPECTED_SIZE;
-      if (finishWrite || bufferOffset != 0) {
-        initiateWrite();
-        flushSome(finishWrite);
+    try {
+      if (!checkComplete()) {
+        boolean finishWrite =
+            expectedSize == COMPRESSED_EXPECTED_SIZE || expectedSize == UNLIMITED_EXPECTED_SIZE;
+        if (finishWrite || bufferOffset != 0) {
+          initiateWrite();
+          flushSome(finishWrite);
+        }
+        cancelled = !finishWrite && offset + writtenBytes + bufferOffset != expectedSize;
       }
-      cancelled = !finishWrite && offset + writtenBytes + bufferOffset != expectedSize;
-    }
-    synchronized (this) {
-      finishedWriteObserver = writeObserver;
-      writeObserver = null;
-    }
-    if (finishedWriteObserver != null) {
-      if (cancelled) {
-        finishedWriteObserver.onError(Status.CANCELLED.asException());
-      } else {
-        finishedWriteObserver.onCompleted();
+    } catch (Exception e) {
+      cancelled = true;
+      // If we're currently racing a concurrent tear down, then don't throw unnecessarily
+      if (!isFullyClosed()) {
+        throw e;
+      }
+    } finally {
+      synchronized (this) {
+        finishedWriteObserver = writeObserver;
+        writeObserver = null;
+      }
+
+      if (finishedWriteObserver != null) {
+        // Always complete the finishedWriteObserver, so it and its associated native memory gets
+        // properly cleaned up.
+        try {
+          if (cancelled) {
+            finishedWriteObserver.onError(Status.CANCELLED.asException());
+          } else {
+            finishedWriteObserver.onCompleted();
+          }
+        } catch (IllegalStateException e) {
+          // If gRPC has already terminated things we want to avoid needlessly throwing an
+          // IllegalStateException
+        }
       }
     }
   }
@@ -175,16 +213,16 @@ public class StubWriteOutputStream extends FeedbackOutputStream implements Write
       request.setResourceName(resourceName);
     }
     synchronized (this) {
-      // writeObserver can be nulled by a completion race
-      // expect that we are completed in this case
-      if (writeObserver != null) {
+      if (!isGrpcRemoteCallClosed && writeObserver != null) {
         writeObserver.onNext(request.build());
         wasReset = false;
         writtenBytes += bufferOffset;
         bufferOffset = 0;
         sentResourceName = true;
       } else {
-        checkState(writeFuture.isDone(), "writeObserver nulled without completion");
+        checkState(
+            writeFuture.isDone(),
+            "writeObserver nulled or server call closed without writeFuture completion");
       }
     }
   }
@@ -216,7 +254,21 @@ public class StubWriteOutputStream extends FeedbackOutputStream implements Write
     return false;
   }
 
-  private synchronized void initiateWrite() {
+  private synchronized void initiateWrite() throws IOException {
+    if (isFullyClosed) {
+      // If we're already fully closed, then don't initiate another write on this same instance
+      checkState(writeFuture.isDone(), "write fully closed without writeFuture completion");
+      Throwable cause = null;
+      try {
+        writeFuture.get();
+      } catch (ExecutionException e) {
+        cause = e.getCause();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        cause = e;
+      }
+      throw new IOException("write already terminated", cause);
+    }
     if (writeObserver == null) {
       checkNotNull(deadlineAfterUnits);
       writeObserver =
@@ -263,12 +315,23 @@ public class StubWriteOutputStream extends FeedbackOutputStream implements Write
                                 offset + writtenBytes));
                       }
                       writeFuture.setException(exceptionTranslator.apply(t));
+                      synchronized (StubWriteOutputStream.this) {
+                        // onError means a RST_STREAM was sent, so we can assume the stream is
+                        // is closed on both sides.
+                        isGrpcRemoteCallClosed = true;
+                        writeObserver = null;
+                        isFullyClosed = true;
+                      }
                     }
 
                     @Override
                     public void onCompleted() {
+                      // We don't set isFullyClosed here because this is a graceful shutdown. At
+                      // this point we're only half closed. END_STREAM was sent to us and we need
+                      // to send an END_STREAM back. That's why we only mark the remote call as
+                      // closed here, so the class can cleanup and gracefully close.
                       synchronized (StubWriteOutputStream.this) {
-                        writeObserver = null;
+                        isGrpcRemoteCallClosed = true;
                       }
                     }
                   });
@@ -325,7 +388,9 @@ public class StubWriteOutputStream extends FeedbackOutputStream implements Write
 
   @Override
   public synchronized boolean isReady() {
-    checkNotNull(writeObserver);
+    if (isGrpcRemoteCallClosed || writeObserver == null) {
+      return false;
+    }
     ClientCallStreamObserver<WriteRequest> clientCallStreamObserver =
         (ClientCallStreamObserver<WriteRequest>) writeObserver;
     return clientCallStreamObserver.isReady();
@@ -366,9 +431,9 @@ public class StubWriteOutputStream extends FeedbackOutputStream implements Write
 
   @Override
   public FeedbackOutputStream getOutput(
-      long offset, long deadlineAfter, TimeUnit deadlineAfterUnits, Runnable onReadyHandler) {
+      long offset, long deadlineAfter, TimeUnit deadlineAfterUnits, Runnable onReadyHandler)
+      throws IOException {
     // should we be exclusive on return here?
-    // should we react to writeFuture.isDone()?
     this.deadlineAfter = deadlineAfter;
     this.deadlineAfterUnits = deadlineAfterUnits;
     this.onReadyHandler = onReadyHandler;
@@ -383,7 +448,11 @@ public class StubWriteOutputStream extends FeedbackOutputStream implements Write
   @Override
   public ListenableFuture<FeedbackOutputStream> getOutputFuture(
       long offset, long deadlineAfter, TimeUnit deadlineAfterUnits, Runnable onReadyHandler) {
-    return immediateFuture(getOutput(offset, deadlineAfter, deadlineAfterUnits, onReadyHandler));
+    try {
+      return immediateFuture(getOutput(offset, deadlineAfter, deadlineAfterUnits, onReadyHandler));
+    } catch (IOException e) {
+      return immediateFailedFuture(e);
+    }
   }
 
   @Override

--- a/src/test/java/build/buildfarm/common/grpc/BUILD
+++ b/src/test/java/build/buildfarm/common/grpc/BUILD
@@ -22,6 +22,7 @@ java_test(
     srcs = glob(["*Test.java"]),
     test_class = "build.buildfarm.AllTests",
     deps = [
+        "//src/main/java/build/buildfarm/common",
         "//src/main/java/build/buildfarm/common/grpc",
         "//src/test/java/build/buildfarm:test_runner",
         "@buildfarm_maven//:com_google_guava_guava",

--- a/src/test/java/build/buildfarm/common/grpc/StubWriteOutputStreamTest.java
+++ b/src/test/java/build/buildfarm/common/grpc/StubWriteOutputStreamTest.java
@@ -15,12 +15,16 @@
 package build.buildfarm.common.grpc;
 
 import static com.google.common.truth.Truth.assertThat;
-import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import com.google.bytestream.ByteStreamGrpc;
 import com.google.bytestream.ByteStreamGrpc.ByteStreamImplBase;
@@ -30,9 +34,15 @@ import com.google.bytestream.ByteStreamProto.WriteRequest;
 import com.google.bytestream.ByteStreamProto.WriteResponse;
 import com.google.common.base.Suppliers;
 import com.google.protobuf.ByteString;
+import io.grpc.CallOptions;
 import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
 import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.stub.StreamObserver;
@@ -41,7 +51,8 @@ import io.grpc.util.MutableHandlerRegistry;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -74,6 +85,65 @@ public class StubWriteOutputStreamTest {
 
     channel =
         grpcCleanup.register(InProcessChannelBuilder.forName(serverName).directExecutor().build());
+  }
+
+  /** Counts {@code ClientCall.cancel(...)} invocations on the test channel. */
+  private static ClientInterceptor recordingCancelInterceptor(AtomicInteger cancelCount) {
+    return new ClientInterceptor() {
+      @Override
+      public <Q, R> ClientCall<Q, R> interceptCall(
+          MethodDescriptor<Q, R> method, CallOptions callOptions, Channel next) {
+        return new SimpleForwardingClientCall<Q, R>(next.newCall(method, callOptions)) {
+          @Override
+          public void cancel(String message, Throwable cause) {
+            cancelCount.incrementAndGet();
+            super.cancel(message, cause);
+          }
+        };
+      }
+    };
+  }
+
+  /** Registers a ByteStream service whose {@code write} returns a fresh mock request observer. */
+  @SuppressWarnings("unchecked")
+  private void registerMockByteStreamService() {
+    serviceRegistry.addService(
+        new ByteStreamImplBase() {
+          @Override
+          public StreamObserver<WriteRequest> write(
+              StreamObserver<WriteResponse> responseObserver) {
+            return mock(StreamObserver.class);
+          }
+        });
+  }
+
+  /**
+   * Registers a ByteStream service that captures the response observer into the given reference and
+   * returns a fresh mock request observer. Lets tests drive the response side via {@code
+   * captured.get().onNext / onError / onCompleted}.
+   */
+  @SuppressWarnings("unchecked")
+  private void registerCapturingByteStreamService(
+      AtomicReference<StreamObserver<WriteResponse>> captured) {
+    serviceRegistry.addService(
+        new ByteStreamImplBase() {
+          @Override
+          public StreamObserver<WriteRequest> write(
+              StreamObserver<WriteResponse> responseObserver) {
+            captured.set(responseObserver);
+            return mock(StreamObserver.class);
+          }
+        });
+  }
+
+  private StubWriteOutputStream newWrite(Channel ch, String resourceName, long expectedSize) {
+    return new StubWriteOutputStream(
+        /* bsBlockingStub= */ null,
+        Suppliers.ofInstance(ByteStreamGrpc.newStub(ch)),
+        resourceName,
+        e -> e,
+        expectedSize,
+        /* autoflush= */ false);
   }
 
   @SuppressWarnings("unchecked")
@@ -160,41 +230,8 @@ public class StubWriteOutputStreamTest {
     assertThat(requests.get(3).getFinishWrite()).isTrue();
   }
 
-  @SuppressWarnings("PMD.EmptyControlStatement")
   @Test
-  public void getOutputCallback() throws Exception {
-    String resourceName = "reset-resource";
-    StubWriteOutputStream write =
-        new StubWriteOutputStream(
-            /* bsBlockingStub= */ null,
-            Suppliers.ofInstance(ByteStreamGrpc.newStub(channel)),
-            resourceName,
-            e -> e,
-            /* expectedSize= */ StubWriteOutputStream.UNLIMITED_EXPECTED_SIZE,
-            /* autoflush= */ true);
-
-    boolean callbackTimedOut = false;
-    try (OutputStream ignored =
-        write.getOutput(
-            1,
-            MICROSECONDS,
-            () -> {
-              try {
-                Thread.sleep(1000);
-              } catch (InterruptedException e) {
-              }
-            })) {
-      write.getFuture().get();
-    } catch (ExecutionException e) {
-      if (e.getCause() instanceof StatusRuntimeException sre) {
-        callbackTimedOut = Status.fromThrowable(sre).getCode() == Status.Code.DEADLINE_EXCEEDED;
-      }
-    }
-    assertThat(callbackTimedOut).isTrue();
-  }
-
-  @Test
-  public void getOutputOffsetMatchesCommittedSize() {
+  public void getOutputOffsetMatchesCommittedSize() throws IOException {
     StreamObserver<WriteRequest> writeObserver = mock(StreamObserver.class);
     serviceRegistry.addService(
         new ByteStreamImplBase() {
@@ -226,5 +263,220 @@ public class StubWriteOutputStreamTest {
     write.getOutput(20, 1, SECONDS, () -> {});
     assertThat(write.getCommittedSize()).isEqualTo(20);
     verifyNoInteractions(writeObserver);
+  }
+
+  @Test
+  public void serverErrorMakesCloseANoOp() throws IOException {
+    // After the response observer's onError, the gRPC stream is fully closed by the server and
+    // Netty's onStreamClosed drains pendingWriteQueue. onError nulls writeObserver and marks the
+    // stream fully torn down, so a subsequent close() is a no-op and does not re-initiate cancel.
+    AtomicInteger cancelCount = new AtomicInteger();
+    AtomicReference<StreamObserver<WriteResponse>> capturedResponseObserver =
+        new AtomicReference<>();
+    registerCapturingByteStreamService(capturedResponseObserver);
+
+    StubWriteOutputStream write =
+        newWrite(
+            ClientInterceptors.intercept(channel, recordingCancelInterceptor(cancelCount)),
+            "sad-path-resource",
+            /* expectedSize= */ 100);
+
+    OutputStream outputStream = write.getOutput(1, SECONDS, () -> {});
+    assertThat(write.isGrpcRemoteCallClosed()).isFalse();
+
+    capturedResponseObserver.get().onError(Status.UNAVAILABLE.asException());
+
+    assertThat(write.isGrpcRemoteCallClosed()).isTrue();
+
+    // close() is a no-op — it does not re-throw the prior failure as
+    // UncheckedExecutionException (which WriteStreamObserver's cancellation listener would log
+    // SEVERE) and does not initiate cancel (the stream is CLOSED, not HALF_CLOSED_REMOTE, so
+    // Netty's onStreamClosed already handled release).
+    outputStream.close();
+    assertThat(cancelCount.get()).isEqualTo(0);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void remoteStreamClosingFirstDoesNotPreventLocalStreamFromClosing() throws IOException {
+    // Observe the client call: the in-process server stops receiving signals once it closes,
+    // so its request observer cannot tell us whether the client subsequently half-closes.
+    ClientCall<WriteRequest, WriteResponse> call = mock(ClientCall.class);
+    Channel mockChannel = mock(Channel.class);
+    when(mockChannel.<WriteRequest, WriteResponse>newCall(any(), any())).thenReturn(call);
+    StubWriteOutputStream write = newWrite(mockChannel, "remote-close-resource", 100);
+    OutputStream out = write.getOutput(1, SECONDS, () -> {});
+    ArgumentCaptor<ClientCall.Listener<WriteResponse>> listener =
+        ArgumentCaptor.forClass(ClientCall.Listener.class);
+    verify(call).start(listener.capture(), any(Metadata.class));
+
+    listener.getValue().onMessage(WriteResponse.newBuilder().setCommittedSize(100).build());
+    listener.getValue().onClose(Status.OK, new Metadata());
+    verify(call, never()).halfClose();
+
+    out.close();
+    out.close();
+
+    verify(call).halfClose();
+    verify(call, never()).cancel(any(), any());
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void closeHappyPathSendsOnCompleted() throws IOException {
+    StreamObserver<WriteRequest> remoteStreamObserver = mock(StreamObserver.class);
+    serviceRegistry.addService(
+        new ByteStreamImplBase() {
+          @Override
+          public StreamObserver<WriteRequest> write(
+              StreamObserver<WriteResponse> responseObserver) {
+            return remoteStreamObserver;
+          }
+        });
+
+    String resourceName = "happy-path-resource";
+    StubWriteOutputStream write =
+        new StubWriteOutputStream(
+            /* bsBlockingStub= */ null,
+            Suppliers.ofInstance(ByteStreamGrpc.newStub(channel)),
+            resourceName,
+            e -> e,
+            /* expectedSize= */ StubWriteOutputStream.UNLIMITED_EXPECTED_SIZE,
+            /* autoflush= */ true);
+
+    ByteString content = ByteString.copyFromUtf8("Hello, World");
+    try (OutputStream out = write.getOutput(1, SECONDS, () -> {})) {
+      content.writeTo(out);
+    }
+
+    // Two onNext calls:
+    // 1. write at 0
+    // 2. finishWrite for close
+    // Then exactly one onCompleted
+    verify(remoteStreamObserver, times(2)).onNext(any(WriteRequest.class));
+    verify(remoteStreamObserver, times(1)).onCompleted();
+    verifyNoMoreInteractions(remoteStreamObserver);
+  }
+
+  @Test
+  public void closeWhenWriteFutureFailedFromOnError_isQuiet() throws IOException {
+    // close() must not re-throw the prior failure: WriteStreamObserver's cancellation listener
+    // catches only IOException, so a RuntimeException would log SEVERE on every cancellation.
+    AtomicReference<StreamObserver<WriteResponse>> capturedResponseObserver =
+        new AtomicReference<>();
+    registerCapturingByteStreamService(capturedResponseObserver);
+
+    StubWriteOutputStream write =
+        newWrite(channel, "error-then-close-resource", /* expectedSize= */ 100);
+
+    OutputStream out = write.getOutput(1, SECONDS, () -> {});
+    capturedResponseObserver.get().onError(Status.UNAVAILABLE.asException());
+
+    // close() must not throw RuntimeException (UncheckedExecutionException of the prior cause).
+    out.close();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void writeAfterServerError_surfacesPriorFailureAndDoesNotInitiateNewCall()
+      throws IOException {
+    // After onError, the response observer has nulled writeObserver. A follow-up write() must
+    // surface the prior failure via checkComplete() rather than fall through to initiateWrite()
+    // and open a fresh gRPC call (which would leak — close() short-circuits on isFullyClosed).
+    // We verify both: the failure throws, AND the underlying ByteStream.write was called exactly
+    // once (the initial getOutput) — no leaked re-initiation.
+    AtomicInteger writeCallCount = new AtomicInteger();
+    AtomicReference<StreamObserver<WriteResponse>> capturedResponseObserver =
+        new AtomicReference<>();
+    serviceRegistry.addService(
+        new ByteStreamImplBase() {
+          @Override
+          public StreamObserver<WriteRequest> write(
+              StreamObserver<WriteResponse> responseObserver) {
+            writeCallCount.incrementAndGet();
+            capturedResponseObserver.set(responseObserver);
+            return mock(StreamObserver.class);
+          }
+        });
+
+    StubWriteOutputStream write =
+        newWrite(channel, "errored-write-resource", /* expectedSize= */ 100);
+    write.getOutput(1, SECONDS, () -> {});
+    assertThat(writeCallCount.get()).isEqualTo(1);
+
+    capturedResponseObserver.get().onError(Status.UNAVAILABLE.asException());
+
+    // A follow-up write surfaces the prior failure. gRPC wraps the server's StatusException as
+    // StatusRuntimeException on the client, which checkComplete throwIfUnchecked()s directly — we
+    // assert on the underlying status code rather than the concrete wrapper class.
+    RuntimeException byteArrayEx =
+        assertThrows(RuntimeException.class, () -> write.write(new byte[] {1}, 0, 1));
+    assertThat(Status.fromThrowable(byteArrayEx).getCode()).isEqualTo(Status.Code.UNAVAILABLE);
+
+    // Crucially: no new gRPC call was initiated. The original observer was already nulled by
+    // onError; absent the checkComplete guard, write(...) would have realized a fresh
+    // writeObserver.
+    assertThat(writeCallCount.get()).isEqualTo(1);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void getOutput_afterServerError_throwsIOExceptionAndDoesNotOpenNewCall()
+      throws IOException {
+    // Symmetric to the cancel case for the response observer's onError teardown path. onError
+    // sets isFullyClosed=true, so a follow-up getOutput must not open a fresh call.
+    AtomicInteger writeCallCount = new AtomicInteger();
+    AtomicReference<StreamObserver<WriteResponse>> capturedResponseObserver =
+        new AtomicReference<>();
+    serviceRegistry.addService(
+        new ByteStreamImplBase() {
+          @Override
+          public StreamObserver<WriteRequest> write(
+              StreamObserver<WriteResponse> responseObserver) {
+            writeCallCount.incrementAndGet();
+            capturedResponseObserver.set(responseObserver);
+            return mock(StreamObserver.class);
+          }
+        });
+
+    StubWriteOutputStream write =
+        newWrite(channel, "error-then-getoutput-resource", /* expectedSize= */ 100);
+    write.getOutput(1, SECONDS, () -> {});
+    assertThat(writeCallCount.get()).isEqualTo(1);
+
+    capturedResponseObserver.get().onError(Status.UNAVAILABLE.asException());
+    assertThat(write.isFullyClosed()).isTrue();
+
+    IOException ex = assertThrows(IOException.class, () -> write.getOutput(1, SECONDS, () -> {}));
+    // Server's UNAVAILABLE is preserved as the cause (gRPC client wraps it as
+    // StatusRuntimeException; Status.fromThrowable walks the chain).
+    assertThat(Status.fromThrowable(ex).getCode()).isEqualTo(Status.Code.UNAVAILABLE);
+
+    assertThat(writeCallCount.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void getOutput_afterServerErrorWhileInterrupted_preservesInterruptedException()
+      throws IOException {
+    AtomicReference<StreamObserver<WriteResponse>> capturedResponseObserver =
+        new AtomicReference<>();
+    registerCapturingByteStreamService(capturedResponseObserver);
+
+    StubWriteOutputStream write =
+        newWrite(channel, "interrupted-after-error-resource", /* expectedSize= */ 100);
+    write.getOutput(1, SECONDS, () -> {});
+    capturedResponseObserver.get().onError(Status.UNAVAILABLE.asException());
+
+    Thread.currentThread().interrupt();
+    try {
+      IOException exception =
+          assertThrows(IOException.class, () -> write.getOutput(1, SECONDS, () -> {}));
+
+      assertThat(exception).hasCauseThat().isInstanceOf(InterruptedException.class);
+      assertThat(Thread.currentThread().isInterrupted()).isTrue();
+    } finally {
+      // Do not leak the interrupt into the test runner.
+      Thread.interrupted();
+    }
   }
 }


### PR DESCRIPTION
This commit fixes two native memory leaks in StubWriteOutputStream:

1. Currently StubWriteOutputStream.close() can throw an exception and prevent the onError() or onCompleted() functions from being called on the finishedWriteObserver. That error being thrown can also prevent writeObserver from being nulled.

2. Currently When the remote gRPC stream closes before the local, writeObserver is set to null, which prevents onError() or onCompleted() from being called when close() is called.

In both of these scenarios the local gRPC stream doesn't get properly closed and Netty never releases a native memory byte buffers that were allocated using Unsafe. This causes a native memory leak.

This change fixes both leaks and adds tests for them that fail without the fix and pass with the fix.

It fixes scenario 1 by moving observer cleanup into a finally block. That way the cleanup functions are always called. We also make sure that writeObserver is always nulled out.

It fixes scenario 2 by using a boolean to separately track whether the remote gRPC stream is closed. That way the local stream still gets closed in the close() function regardless of whether the remote is closed.

This change by itself doesn't fully fix the native memory leaks. There's a few other ways native memory can leak in this class.

This change also introduces a test that fails without the fix and passes with the fix.