### PR TITLE
fix(persistent): move outputs back for REAPI >= 2.1 clients (output_paths)

### DIFF
--- a/src/main/java/build/buildfarm/worker/persistent/PersistentExecutor.java
+++ b/src/main/java/build/buildfarm/worker/persistent/PersistentExecutor.java
@@ -57,6 +57,8 @@ public class PersistentExecutor {
   // TODO Revisit hardcoded actions
   static final String JAVABUILDER_JAR =
       "external/remote_java_tools/java_tools/JavaBuilder_deploy.jar";
+  // bzlmod repos are named e.g. rules_java++toolchains+remote_java_tools
+  static final String JAVABUILDER_JAR_SUFFIX = "java_tools/JavaBuilder_deploy.jar";
 
   private static final String SCALAC_EXEC_NAME = "Scalac";
   private static final String JAVAC_EXEC_NAME = "JavaBuilder";
@@ -285,7 +287,7 @@ public class PersistentExecutor {
     boolean isScalac = argsList.size() > 1 && argsList.getFirst().endsWith("scalac/scalac");
     if (isScalac) {
       return SCALAC_EXEC_NAME;
-    } else if (argsList.contains(JAVABUILDER_JAR)) {
+    } else if (argsList.stream().anyMatch(a -> a.endsWith(JAVABUILDER_JAR_SUFFIX))) {
       return JAVAC_EXEC_NAME;
     }
     return "SomeOtherExec";

--- a/src/main/java/build/buildfarm/worker/persistent/ProtoCoordinator.java
+++ b/src/main/java/build/buildfarm/worker/persistent/ProtoCoordinator.java
@@ -22,6 +22,7 @@ import com.google.protobuf.util.Durations;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.UUID;
@@ -245,13 +246,26 @@ public class ProtoCoordinator extends WorkCoordinator<RequestCtx, ResponseCtx, C
       Files.createDirectories(outputDirPath);
     }
 
-    for (String relOutput : context.outputFiles) {
+    // REAPI >= 2.1 clients (Bazel >= 7) populate Command.output_paths and leave
+    // output_files/output_directories empty. Fall back to output_paths so the
+    // worker's outputs are moved back to the operation root.
+    Iterable<String> outputs = context.outputFiles;
+    if (context.outputFiles.isEmpty() && context.outputDirectories.isEmpty()) {
+      outputs = context.outputPaths;
+    }
+
+    for (String relOutput : outputs) {
       Path execOutputPath = workerExecRoot.resolve(relOutput);
       Path opOutputPath = opRoot.resolve(relOutput);
       // Don't fail here if the action failed to produce a file.
       // The missing file will be handled just like it is for non-worker actions.
       if (Files.exists(execOutputPath)) {
-        FileAccessUtils.moveFile(execOutputPath, opOutputPath);
+        Files.createDirectories(opOutputPath.getParent());
+        if (Files.isDirectory(execOutputPath)) {
+          Files.move(execOutputPath, opOutputPath, StandardCopyOption.REPLACE_EXISTING);
+        } else {
+          FileAccessUtils.moveFile(execOutputPath, opOutputPath);
+        }
       }
     }
   }


### PR DESCRIPTION
## Problem

Remote persistent workers (`--experimental_remote_mark_tool_inputs`) fail for every action with recent Bazel clients:

```
ERROR: Building java/ind/libi1.jar (1 source file) failed: (Exit 34): mandatory output java/ind/libi1.jdeps was not created
```

Root cause: since #1244 the normal execution path honors `Command.output_paths`, but `ProtoCoordinator.moveOutputsToOperationRoot` still iterates only `output_files` / `output_directories`. Buildfarm advertises REAPI `2.11` (`CapabilitiesService`), so Bazel >= 7 sends `output_paths` and leaves the legacy fields empty. The persistent worker finishes successfully (outputs exist in its exec root) but nothing is moved back to the operation root, so the client sees missing outputs. `WorkFilesContext.outputPaths` was already captured but only used in the error log.

A second, minor issue: `PersistentExecutor` detects JavaBuilder via the hard-coded `external/remote_java_tools/java_tools/JavaBuilder_deploy.jar`. Under bzlmod the repository is `rules_java++toolchains+remote_java_tools`, so Javac actions were keyed as `SomeOtherExec` (and their env was not cleared from the worker key).

## Fix

- Fall back to `output_paths` when `output_files`/`output_directories` are empty; handle both files and directories; create parent dirs.
- Detect JavaBuilder by the `java_tools/JavaBuilder_deploy.jar` suffix.

## Verification

Bazel 9.2.0 client, `buildfarm-server` / `buildfarm-worker` 2.17.1 (worker jar patched with these two classes), `java_library` targets:

- Before: 100% of persistent `Javac` actions fail with "mandatory output ... was not created"; outputs found orphaned under `/tmp/worker/persistent/work-root_*/<uuid>/bazel-out/...`.
- After: `76 processes: 1 internal, 75 remote. Build completed successfully`; work root is now `work-root_JavaBuilder_*`; JavaBuilder JVMs are reused across actions.
- Outputs (144 `.jar`/`.jdeps`, `--remote_download_outputs=all`) are byte-identical with and without `--experimental_remote_mark_tool_inputs`.
- Worker-side `execution_time_ms` per `Javac` action: ~800 ms cold-JVM vs ~170 ms persistent.

## Not addressed here (happy to open issues)

- `CommonsPool` never evicts idle persistent workers (`timeBetweenEvictionRunsMillis = -1`), so JVMs for every tool hash ever seen stay alive until the worker exits.
- JavaBuilder scratch directories (`_javac/<target>/lib<target>_classes/`) written under the request exec root are not cleaned up; only non-tool inputs are removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
